### PR TITLE
feat: LINE Bot食材検索のクイックリプライ機能

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:recipe": "tsx scripts/test-recipe-registration.ts",
+    "test:bot": "tsx scripts/test-bot.ts",
     "collect:urls": "tsx scripts/collect-recipe-urls.ts",
     "prepare": "husky"
   },

--- a/scripts/test-bot.ts
+++ b/scripts/test-bot.ts
@@ -1,0 +1,185 @@
+/**
+ * LINE Botレスポンステストスクリプト
+ *
+ * 使用方法:
+ *   npm run test:bot "食材"
+ *   npm run test:bot "鶏肉 玉ねぎ"
+ *   npm run test:bot "使い方"
+ *
+ * 前提条件:
+ *   - ローカル Supabase が起動していること (supabase start)
+ *   - 開発用ユーザー (dev-user-001) がシードされていること
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+// .env.local から環境変数を読み込む（importより先に実行）
+const envPath = path.join(__dirname, '../.env.local')
+if (fs.existsSync(envPath)) {
+  const envContent = fs.readFileSync(envPath, 'utf-8')
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      const value = valueParts.join('=')
+      if (key && value && !process.env[key]) {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
+const LINE_USER_ID = process.env.LINE_USER_ID || 'dev-user-001'
+
+async function main() {
+  // 環境変数設定後に動的import
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const lineBotSdk = await import('@line/bot-sdk')
+  const { isIngredientSearchKeyword, handleIngredientSearchPrompt, handleSearch } = await import(
+    '../src/lib/line/search-handler'
+  )
+
+  type MessagingApiClient = lineBotSdk.messagingApi.MessagingApiClient
+  type Message = lineBotSdk.messagingApi.Message
+  type TextMessage = lineBotSdk.messagingApi.TextMessage
+  type FlexMessage = lineBotSdk.messagingApi.FlexMessage
+  type MessageAction = lineBotSdk.messagingApi.MessageAction
+  type URIAction = lineBotSdk.messagingApi.URIAction
+  type QuickReplyItem = lineBotSdk.messagingApi.QuickReplyItem
+  type ReplyMessageResponse = lineBotSdk.messagingApi.ReplyMessageResponse
+
+  // キャプチャされたレスポンス
+  interface CapturedResponse {
+    messages: Message[]
+  }
+
+  // モッククライアントを作成
+  function createMockClient() {
+    let captured: CapturedResponse | null = null
+
+    const client = {
+      replyMessage: async (request: { replyToken: string; messages: Message[] }) => {
+        captured = { messages: request.messages }
+        return {} as ReplyMessageResponse
+      },
+    } as unknown as MessagingApiClient
+
+    return {
+      client,
+      getResponse: () => captured,
+    }
+  }
+
+  // ダミーのensureUser関数
+  async function ensureUser(): Promise<void> {
+    // 開発用ユーザーは既にシードされているので何もしない
+  }
+
+  // ヘルプキーワード判定
+  function isHelpKeyword(text: string): boolean {
+    const keywords = ['使い方', 'ヘルプ', 'help', '?', '？']
+    const normalizedText = text.trim().toLowerCase()
+    return keywords.some((keyword) => normalizedText === keyword.toLowerCase())
+  }
+
+  // クイックリプライを整形
+  function formatQuickReply(items: QuickReplyItem[]): void {
+    console.log('\n   quickReply:')
+    for (const item of items) {
+      if (item.action?.type === 'message') {
+        const action = item.action as MessageAction
+        console.log(`     - [${action.label}] → "${action.text}"`)
+      } else if (item.action?.type === 'uri') {
+        const action = item.action as URIAction
+        console.log(`     - [${action.label}] → ${action.uri}`)
+      }
+    }
+  }
+
+  // レスポンスを整形して出力
+  function formatResponse(response: CapturedResponse): void {
+    for (const msg of response.messages) {
+      console.log('\n📥 Response:')
+      console.log(`   type: ${msg.type}`)
+
+      if (msg.type === 'text') {
+        const textMsg = msg as TextMessage
+        console.log(`   text: ${textMsg.text.replace(/\n/g, '\n         ')}`)
+        if (textMsg.quickReply?.items) {
+          formatQuickReply(textMsg.quickReply.items)
+        }
+      } else if (msg.type === 'flex') {
+        const flexMsg = msg as FlexMessage
+        console.log(`   altText: ${flexMsg.altText}`)
+        console.log(`   contents: (Flex Message)`)
+      }
+    }
+  }
+
+  const args = process.argv.slice(2)
+
+  if (args.length === 0) {
+    console.log('Usage: npm run test:bot "<message>"')
+    console.log('')
+    console.log('Examples:')
+    console.log('  npm run test:bot "食材"')
+    console.log('  npm run test:bot "鶏肉 玉ねぎ"')
+    console.log('  npm run test:bot "使い方"')
+    process.exit(1)
+  }
+
+  const text = args[0]
+  console.log('🧪 LINE Bot Response Test')
+  console.log('='.repeat(40))
+  console.log(`📤 Input: "${text}"`)
+  console.log(`👤 User: ${LINE_USER_ID}`)
+
+  const { client, getResponse } = createMockClient()
+  const replyToken = 'test-reply-token'
+
+  try {
+    // ヘルプキーワードの場合
+    if (isHelpKeyword(text)) {
+      console.log('\n🔀 Route: Help')
+      const helpText = `📖 RecipeHub の使い方
+
+【レシピを保存する】
+レシピサイトのURLをこのトークに送るだけ！
+AIが自動で食材を解析して保存します。
+
+【レシピを探す】
+画面下のメニューから「レシピ一覧」をタップ。
+食材で絞り込み検索もできます。
+
+【対応サイト】
+クックパッド、クラシル、デリッシュキッチンなど主要レシピサイトに対応しています。`
+      console.log('\n📥 Response:')
+      console.log(`   type: text`)
+      console.log(`   text: ${helpText.replace(/\n/g, '\n         ')}`)
+      return
+    }
+
+    // 食材検索キーワードの場合
+    if (isIngredientSearchKeyword(text)) {
+      console.log('\n🔀 Route: Ingredient Search Prompt')
+      await handleIngredientSearchPrompt(client, replyToken, LINE_USER_ID)
+    } else {
+      // 通常の検索
+      console.log('\n🔀 Route: Search')
+      await handleSearch(client, replyToken, LINE_USER_ID, text, ensureUser)
+    }
+
+    const response = getResponse()
+    if (response) {
+      formatResponse(response)
+    } else {
+      console.log('\n⚠️  No response captured')
+    }
+  } catch (err) {
+    console.error('\n❌ Error:', err)
+    process.exit(1)
+  }
+}
+
+main()

--- a/src/app/api/webhook/line/route.ts
+++ b/src/app/api/webhook/line/route.ts
@@ -4,7 +4,7 @@ import { parseRecipe } from '@/lib/recipe/parse-recipe'
 import { createRecipe } from '@/lib/db/queries/recipes'
 import { createServerClient } from '@/lib/db/client'
 import { createRecipeMessage, RecipeCardData } from '@/lib/line/flex-message'
-import { handleSearch } from '@/lib/line/search-handler'
+import { handleSearch, isIngredientSearchKeyword, handleIngredientSearchPrompt } from '@/lib/line/search-handler'
 
 const config = {
   channelSecret: process.env.LINE_CHANNEL_SECRET || '',
@@ -220,6 +220,12 @@ async function handleMessageEvent(event: WebhookEvent): Promise<void> {
   // ヘルプキーワードの場合
   if (isHelpKeyword(text)) {
     await replyHelp(event.replyToken)
+    return
+  }
+
+  // 食材検索キーワードの場合
+  if (isIngredientSearchKeyword(text)) {
+    await handleIngredientSearchPrompt(client, event.replyToken, event.source.userId)
     return
   }
 

--- a/src/lib/db/queries/frequent-ingredients.ts
+++ b/src/lib/db/queries/frequent-ingredients.ts
@@ -1,0 +1,62 @@
+import { createServerClient } from '@/lib/db/client'
+
+export interface FrequentIngredient {
+  id: string
+  name: string
+  recipeCount: number
+}
+
+/**
+ * ユーザーの登録レシピに多く使われている食材を取得（RPC版）
+ * @param userId 内部ユーザーID (UUID)
+ * @param limit 取得件数（デフォルト10）
+ */
+export async function fetchFrequentIngredients(
+  userId: string,
+  limit: number = 10
+): Promise<FrequentIngredient[]> {
+  const supabase = createServerClient()
+
+  const { data, error } = await supabase.rpc('get_frequent_ingredients', {
+    p_user_id: userId,
+    p_limit: limit,
+  })
+
+  if (error) {
+    console.error('[fetchFrequentIngredients] RPC error:', error)
+    return []
+  }
+
+  if (!data || data.length === 0) return []
+
+  return data.map((row: { id: string; name: string; recipe_count: number }) => ({
+    id: row.id,
+    name: row.name,
+    recipeCount: row.recipe_count,
+  }))
+}
+
+/**
+ * LINE ユーザーIDから頻出食材を取得
+ * @param lineUserId LINE ユーザーID
+ * @param limit 取得件数
+ */
+export async function fetchFrequentIngredientsByLineUserId(
+  lineUserId: string,
+  limit: number = 10
+): Promise<FrequentIngredient[]> {
+  const supabase = createServerClient()
+
+  // LINE ユーザーIDから内部ユーザーIDを取得
+  const { data: user, error: userError } = await supabase
+    .from('users')
+    .select('id')
+    .eq('line_user_id', lineUserId)
+    .single()
+
+  if (userError || !user) {
+    return []
+  }
+
+  return fetchFrequentIngredients(user.id, limit)
+}

--- a/src/lib/line/default-ingredients.ts
+++ b/src/lib/line/default-ingredients.ts
@@ -1,0 +1,61 @@
+import { createServerClient } from '@/lib/db/client'
+
+/**
+ * レシピ未登録の新規ユーザー向けデフォルト食材リスト
+ * seed/ingredients.json の name と一致する必要あり
+ */
+const DEFAULT_INGREDIENT_NAMES = [
+  '鶏肉',
+  '豚肉',
+  'たまご',
+  'キャベツ',
+  'たまねぎ',
+  'じゃがいも',
+  'にんじん',
+  '豆腐',
+  '鮭',
+  'もやし',
+]
+
+export interface DefaultIngredient {
+  id: string
+  name: string
+}
+
+// メモリキャッシュ（サーバー起動中は保持）
+let cachedDefaultIngredients: DefaultIngredient[] | null = null
+
+/**
+ * デフォルト食材をDBから取得（キャッシュあり）
+ */
+export async function getDefaultIngredients(): Promise<DefaultIngredient[]> {
+  if (cachedDefaultIngredients) {
+    return cachedDefaultIngredients
+  }
+
+  const supabase = createServerClient()
+
+  const { data, error } = await supabase
+    .from('ingredients')
+    .select('id, name')
+    .in('name', DEFAULT_INGREDIENT_NAMES)
+
+  if (error) {
+    console.error('[getDefaultIngredients] Error:', error)
+    return []
+  }
+
+  // 定義順にソート
+  const sortedData = (data ?? []).sort((a, b) => {
+    const indexA = DEFAULT_INGREDIENT_NAMES.indexOf(a.name)
+    const indexB = DEFAULT_INGREDIENT_NAMES.indexOf(b.name)
+    return indexA - indexB
+  })
+
+  cachedDefaultIngredients = sortedData.map((item) => ({
+    id: item.id,
+    name: item.name,
+  }))
+
+  return cachedDefaultIngredients
+}

--- a/src/lib/line/quick-reply.ts
+++ b/src/lib/line/quick-reply.ts
@@ -1,0 +1,68 @@
+import type { messagingApi } from '@line/bot-sdk'
+import { fetchFrequentIngredientsByLineUserId } from '@/lib/db/queries/frequent-ingredients'
+import { getDefaultIngredients } from './default-ingredients'
+
+type QuickReplyItem = messagingApi.QuickReplyItem
+
+/** クイックリプライに表示する食材の最大数（「もっと見る」ボタン用に1枠確保） */
+const MAX_INGREDIENT_ITEMS = 12
+
+/**
+ * 食材検索用のクイックリプライを構築
+ * @param lineUserId LINE ユーザーID
+ * @returns QuickReplyItem の配列
+ */
+export async function buildIngredientQuickReply(lineUserId: string): Promise<QuickReplyItem[]> {
+  const items: QuickReplyItem[] = []
+
+  // ユーザーの頻出食材を取得
+  let ingredients: { id: string; name: string }[] = []
+
+  try {
+    const frequent = await fetchFrequentIngredientsByLineUserId(lineUserId, MAX_INGREDIENT_ITEMS)
+    ingredients = frequent.map((f) => ({ id: f.id, name: f.name }))
+  } catch (err) {
+    console.error('[buildIngredientQuickReply] Error fetching frequent ingredients:', err)
+  }
+
+  // 頻出食材が足りない場合はデフォルトで補完
+  if (ingredients.length < MAX_INGREDIENT_ITEMS) {
+    try {
+      const defaults = await getDefaultIngredients()
+      const existingIds = new Set(ingredients.map((i) => i.id))
+      const additional = defaults
+        .filter((d) => !existingIds.has(d.id))
+        .slice(0, MAX_INGREDIENT_ITEMS - ingredients.length)
+      ingredients = [...ingredients, ...additional]
+    } catch (err) {
+      console.error('[buildIngredientQuickReply] Error fetching default ingredients:', err)
+    }
+  }
+
+  // 食材ボタンを追加
+  for (const ing of ingredients.slice(0, MAX_INGREDIENT_ITEMS)) {
+    items.push({
+      type: 'action',
+      action: {
+        type: 'message',
+        label: ing.name,
+        text: ing.name,
+      },
+    })
+  }
+
+  // 「もっと食材を見る」ボタンを追加（LIFF遷移）
+  const liffId = process.env.NEXT_PUBLIC_LIFF_ID || ''
+  if (liffId) {
+    items.push({
+      type: 'action',
+      action: {
+        type: 'uri',
+        label: 'もっと食材を見る',
+        uri: `https://liff.line.me/${liffId}`,
+      },
+    })
+  }
+
+  return items
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -242,7 +242,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      get_frequent_ingredients: {
+        Args: { p_limit?: number; p_user_id: string }
+        Returns: {
+          id: string
+          name: string
+          recipe_count: number
+        }[]
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20260208000000_frequent_ingredients_rpc.sql
+++ b/supabase/migrations/20260208000000_frequent_ingredients_rpc.sql
@@ -1,0 +1,30 @@
+-- ユーザーの登録レシピに多く使われている食材を取得するRPC関数
+CREATE OR REPLACE FUNCTION get_frequent_ingredients(
+  p_user_id UUID,
+  p_limit INTEGER DEFAULT 10
+)
+RETURNS TABLE (
+  id UUID,
+  name TEXT,
+  recipe_count BIGINT
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT
+    i.id,
+    i.name,
+    COUNT(*) as recipe_count
+  FROM recipe_ingredients ri
+  JOIN recipes r ON ri.recipe_id = r.id
+  JOIN ingredients i ON ri.ingredient_id = i.id
+  WHERE r.user_id = p_user_id
+  GROUP BY i.id, i.name
+  ORDER BY recipe_count DESC
+  LIMIT p_limit;
+$$;
+
+-- 関数に対する実行権限を付与
+GRANT EXECUTE ON FUNCTION get_frequent_ingredients(UUID, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_frequent_ingredients(UUID, INTEGER) TO service_role;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
## Summary

- リッチメニュー「食材で探す」をタップすると、クイックリプライで食材を選択できる機能を追加
- ユーザーが登録したレシピでよく使われている食材を表示（パーソナライズ）
- 新規ユーザーにはデフォルトの人気食材を表示
- 「もっと食材を見る」ボタンでLIFFに遷移

## Changes

### New Files
- `src/lib/db/queries/frequent-ingredients.ts` - 頻出食材クエリ（RPC呼び出し）
- `src/lib/line/default-ingredients.ts` - デフォルト食材リスト
- `src/lib/line/quick-reply.ts` - クイックリプライビルダー
- `supabase/migrations/20260208000000_frequent_ingredients_rpc.sql` - RPC関数

### Modified Files
- `src/lib/line/search-handler.ts` - 食材検索キーワード判定・ハンドラー追加
- `src/app/api/webhook/line/route.ts` - 分岐追加

## User Flow

```
[食材で探す] → テキスト「食材」送信
      ↓
案内メッセージ + クイックリプライ
[鶏肉] [豚肉] [卵] ... [もっと食材を見る]
      ↓
タップ or 入力 → 検索結果表示
```

## Test plan

- [ ] LINE Official Account Managerでリッチメニューの「食材で探す」をテキスト送信（`食材`）に変更
- [ ] LINEで「食材」と送信し、クイックリプライが表示されることを確認
- [ ] レシピを登録済みのユーザーでは登録レシピに多い食材が表示されることを確認
- [ ] 新規ユーザーではデフォルト食材が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)