### PR TITLE
feat: batch embedding generation with pg_cron and Edge Function

### DIFF
--- a/.github/workflows/supabase-functions.yml
+++ b/.github/workflows/supabase-functions.yml
@@ -1,0 +1,23 @@
+name: Deploy Supabase Functions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/functions/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy Edge Functions
+        run: supabase functions deploy --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,26 +1,23 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-02-09 (LP・利用規約・プライバシーポリシーページ作成)
+2026-02-10 (ベクトル検索機能追加・ステージングバックフィル完了)
 
 ## 現在のフェーズ
-フェーズ 3：LINE Messaging API 連携 - **Bot検索機能完了・LP作成完了**
+フェーズ 3：LINE Messaging API 連携 - **Bot検索機能完了・ベクトル検索追加**
 
 ## 直近の完了タスク
-- [x] **LPページ作成（/lp）**
-  - ヒーローセクション（スマホモックアップ、食材イラスト付き）
-  - 3ステップ紹介（URL送信 → 自動タグ付け → 食材検索）
-  - スクリーンショットセクション（プレースホルダー）
-  - FAQセクション（アコーディオン）
-  - CTAセクション（LINE友だち追加ボタン）
-- [x] **利用規約・プライバシーポリシーページ作成**
-  - `/terms` - 利用規約
-  - `/privacy` - プライバシーポリシー
-  - LPフッターにリンク追加
-- [x] **LP改善**
-  - 「無料で使えます」→ チェックマークリスト（✓完全無料 ✓登録かんたん ✓広告なし）
-  - 「AI」→「自動」に表現変更（実態に合わせて）
-- [x] **リッチメニュー設定変更（手動）** - 完了済み
+- [x] **ベクトル検索機能の実装**
+  - pgvector 拡張と embedding カラム追加（3072次元）
+  - Google gemini-embedding-001 を使用（無料枠: 1000 RPD）
+  - ハイブリッド検索: ILIKE で3件未満の場合、ベクトル検索で補完
+  - 類似度閾値: 0.65（精度調整済み）
+  - レシピ作成時に埋め込みを自動生成
+- [x] **バックフィルスクリプト作成**
+  - `scripts/backfill-embeddings.ts` - 既存レシピの埋め込み生成
+  - `--env=staging` オプションでステージング環境に対応
+- [x] **ステージング環境のバックフィル実行**
+  - 5件のレシピの埋め込み生成完了
 
 ## 進行中のタスク
 なし
@@ -33,7 +30,6 @@
 - [ ] **LINE友だち追加URL設定**
   - 環境変数 `NEXT_PUBLIC_LINE_FRIEND_URL` に設定
 - [ ] **さらなるマッチング改善（任意）**
-  - 表記ゆれ対応: ニラ→にら、レンコン→れんこん
   - 食材マスター追加: 長芋、小ねぎ、ローズマリー、ミント など
 - [ ] リッチメニュー画像の本番デザイン作成
 
@@ -42,10 +38,16 @@
   - 詳細は `/Users/uemuramakoto/.claude/plans/distributed-frolicking-quasar.md` 参照
 
 ## ブロッカー・注意点
+- **ベクトル検索の制限:**
+  - pgvector インデックス（IVFFlat/HNSW）は 2000 次元が上限
+  - 3072 次元のため、インデックスなしで運用（数千件規模では問題なし）
+- **バックフィル実行:** 新環境では `npx tsx scripts/backfill-embeddings.ts --env=staging` を実行
 - **ローカル開発:** `.env.local` の `NEXT_PUBLIC_LIFF_ID` を空にするとLINEログインなしで動作
 - ローカル開発時は `supabase start` で起動が必要
 - **RLS注意:** Webhookでは `createServerClient`（Secret Key）を使用すること
-- **Gemini API無料枠:** `gemini-2.5-flash` を使用（20 requests/day程度）
+- **Gemini API無料枠:**
+  - `gemini-2.5-flash` を使用（20 requests/day程度）
+  - `gemini-embedding-001` は 1000 RPD
 - **DB型更新時:** `supabase gen types typescript --local > src/types/database.ts` を実行
 - **GitHub Secrets:** `SUPABASE_ACCESS_TOKEN` と `SUPABASE_PROJECT_REF` が必要（CI用）
 - **マイグレーション順序:** 食材マスター → エイリアスの順で適用される（タイムスタンプで制御）
@@ -54,11 +56,11 @@
 
 ## コミット履歴（直近）
 ```
+2b529a1 Merge pull request #4 from mktu/feature/add-vector-search
+9ed5f3d feat: add vector search for recipe titles
+f8a0cce docs: update SESSION.md for session handoff
 f9de978 refactor: replace "AI" with "自動" in LP copy
 cc82112 feat: add privacy policy and terms of service pages
-1a13a33 feat: add landing page (/lp)
-d2744de docs: update SESSION.md for session handoff
-47f5f2f docs: add LINE Bot test script usage to README
 ```
 
 ## GitHubリポジトリ
@@ -67,8 +69,8 @@ https://github.com/mktu/recipe-app
 ## 参照すべきファイル
 - `requirements.md` - プロジェクト要件定義
 - `CLAUDE.md` - 開発ルール・ガイド
-- `src/app/lp/page.tsx` - LPページ
-- `src/components/features/lp/` - LPコンポーネント群
-- `src/app/privacy/page.tsx` - プライバシーポリシー
-- `src/app/terms/page.tsx` - 利用規約
-- `src/components/features/legal/` - 法的ページコンポーネント
+- `src/lib/embedding/` - 埋め込み生成クライアント
+- `src/lib/db/queries/recipe-embedding.ts` - ベクトル検索クエリ
+- `supabase/migrations/20260209000000_add_vector_search.sql` - pgvector マイグレーション
+- `scripts/backfill-embeddings.ts` - バックフィルスクリプト
+- `.env.staging` - ステージング環境変数（要設定）

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Supabase Edge Functions (Deno runtime)
+    "supabase/functions/**",
   ]),
   // ファイルサイズ・複雑度のルール（肥大化防止）
   {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:recipe": "tsx scripts/test-recipe-registration.ts",
+    "test:recipe:with-embeddings": "npm run test:recipe -- && npm run backfill:embeddings",
     "test:bot": "tsx scripts/test-bot.ts",
     "collect:urls": "tsx scripts/collect-recipe-urls.ts",
     "backfill:embeddings": "tsx scripts/backfill-embeddings.ts",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:bot": "tsx scripts/test-bot.ts",
     "collect:urls": "tsx scripts/collect-recipe-urls.ts",
     "backfill:embeddings": "tsx scripts/backfill-embeddings.ts",
+    "functions:serve": "supabase functions serve --env-file .env.local",
+    "functions:invoke": "curl -X POST http://localhost:54321/functions/v1/generate-embeddings -H 'Content-Type: application/json' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0'",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -104,6 +104,52 @@ LINE Botのレスポンスをローカルで確認できる。ngrok不要。
      ...
 ```
 
+## 埋め込み生成（ベクトル検索用）
+
+レシピ登録時は `title_embedding = NULL` で保存され、バッチ処理で埋め込みを生成する。
+
+### ローカルでの埋め込み生成
+
+**方法1: バックフィルスクリプト（推奨）**
+
+```bash
+# レシピ登録 + 埋め込み生成をセットで実行
+npm run test:recipe:with-embeddings -- --limit=5
+
+# 埋め込みのみ生成（既存レシピ対象）
+npm run backfill:embeddings
+```
+
+**方法2: Edge Function をローカル実行**
+
+```bash
+# 1. Edge Function サーバーを起動（別ターミナル）
+npm run functions:serve
+
+# 2. Edge Function を呼び出し
+npm run functions:invoke
+```
+
+**出力例:**
+```json
+{"message":"Embedding generation completed","processed":3,"succeeded":3,"failed":0}
+```
+
+### ステージング/本番環境
+
+```bash
+# ステージング環境のバックフィル
+npm run backfill:embeddings -- --env=staging
+```
+
+本番では pg_cron + Edge Function で5分毎に自動実行される。
+
+### リトライ制限
+
+- 埋め込み生成に失敗したレシピは `embedding_retry_count` がインクリメントされる
+- 3回失敗すると処理対象から除外される
+- リセット: `UPDATE recipes SET embedding_retry_count = 0 WHERE ...`
+
 ## 食材マッチング解析
 
 ```bash

--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -12,13 +12,17 @@
  *   --env=local    → .env.local（デフォルト）
  *   --env=staging  → .env.staging
  *
+ * リトライ制限:
+ *   - embedding_retry_count が MAX_RETRY_COUNT 未満のレシピのみ処理
+ *   - 失敗時はリトライ回数をインクリメント
+ *
  * 注意:
  *   - Gemini Embedding API の無料枠は 1000 RPD
  *   - バッチ間に待機時間を設けてレート制限を回避
  */
 
 import { readFileSync, existsSync } from 'fs'
-import { createClient } from '@supabase/supabase-js'
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
 import { google } from '@ai-sdk/google'
 import { embedMany } from 'ai'
 
@@ -46,6 +50,7 @@ for (const line of envFile.split('\n')) {
 // 設定
 const BATCH_SIZE = 50 // 一度に処理するレシピ数
 const WAIT_MS = 2000 // バッチ間の待機時間 (ms)
+const MAX_RETRY_COUNT = 3 // リトライ上限
 
 // Supabase クライアント
 const supabase = createClient(
@@ -56,15 +61,22 @@ const supabase = createClient(
 // Gemini Embedding モデル
 const embeddingModel = google.embeddingModel('gemini-embedding-001')
 
-async function getRecipesWithoutEmbedding(limit: number) {
+interface Recipe {
+  id: string
+  title: string
+  embedding_retry_count: number
+}
+
+async function getRecipesWithoutEmbedding(limit: number): Promise<Recipe[]> {
   const { data, error } = await supabase
     .from('recipes')
-    .select('id, title')
+    .select('id, title, embedding_retry_count')
     .is('title_embedding', null)
+    .lt('embedding_retry_count', MAX_RETRY_COUNT)
     .limit(limit)
 
   if (error) throw error
-  return data ?? []
+  return (data ?? []) as Recipe[]
 }
 
 async function countRemainingRecipes(): Promise<number> {
@@ -72,6 +84,7 @@ async function countRemainingRecipes(): Promise<number> {
     .from('recipes')
     .select('*', { count: 'exact', head: true })
     .is('title_embedding', null)
+    .lt('embedding_retry_count', MAX_RETRY_COUNT)
 
   if (error) throw error
   return count ?? 0
@@ -83,43 +96,72 @@ async function saveEmbedding(recipeId: string, embedding: number[]) {
     .update({
       title_embedding: JSON.stringify(embedding),
       embedding_generated_at: new Date().toISOString(),
+      embedding_retry_count: 0, // 成功したらリセット
     })
     .eq('id', recipeId)
 
   if (error) throw error
 }
 
-async function processBatch(recipes: { id: string; title: string }[]) {
-  if (recipes.length === 0) return { succeeded: 0, failed: 0 }
+async function incrementRetryCount(
+  client: SupabaseClient,
+  recipeId: string,
+  currentCount: number
+): Promise<void> {
+  const { error } = await client
+    .from('recipes')
+    .update({ embedding_retry_count: currentCount + 1 })
+    .eq('id', recipeId)
 
-  // 一括で埋め込み生成
-  const { embeddings } = await embedMany({
-    model: embeddingModel,
-    values: recipes.map((r) => r.title),
-  })
+  if (error) {
+    console.error(`  Failed to increment retry count for ${recipeId}:`, error)
+  }
+}
+
+async function processBatch(recipes: Recipe[]) {
+  if (recipes.length === 0) return { succeeded: 0, failed: 0, skipped: 0 }
+
+  let embeddings: number[][]
+  try {
+    // 一括で埋め込み生成
+    const result = await embedMany({
+      model: embeddingModel,
+      values: recipes.map((r) => r.title || ' '), // 空文字対策
+    })
+    embeddings = result.embeddings
+  } catch (apiError) {
+    // API 全体が失敗した場合、全レシピのリトライ回数をインクリメント
+    console.error('  Embedding API failed:', apiError)
+    for (const recipe of recipes) {
+      await incrementRetryCount(supabase, recipe.id, recipe.embedding_retry_count)
+    }
+    return { succeeded: 0, failed: recipes.length, skipped: 0 }
+  }
 
   let succeeded = 0
   let failed = 0
 
   // 各レシピに保存
   for (let i = 0; i < recipes.length; i++) {
+    const recipe = recipes[i]
     try {
-      await saveEmbedding(recipes[i].id, embeddings[i])
+      await saveEmbedding(recipe.id, embeddings[i])
       succeeded++
     } catch (err) {
-      console.error(`  Failed to save embedding for ${recipes[i].id}:`, err)
+      console.error(`  Failed to save embedding for ${recipe.id}:`, err)
+      await incrementRetryCount(supabase, recipe.id, recipe.embedding_retry_count)
       failed++
     }
   }
 
-  return { succeeded, failed }
+  return { succeeded, failed, skipped: 0 }
 }
 
 async function main() {
   console.log('=== 埋め込みバックフィル開始 ===\n')
 
   const totalRemaining = await countRemainingRecipes()
-  console.log(`未処理レシピ: ${totalRemaining} 件\n`)
+  console.log(`未処理レシピ: ${totalRemaining} 件（リトライ上限未満）\n`)
 
   if (totalRemaining === 0) {
     console.log('処理対象のレシピがありません。')
@@ -160,6 +202,11 @@ async function main() {
   console.log(`合計処理: ${processed} 件`)
   console.log(`成功: ${totalSucceeded} 件`)
   console.log(`失敗: ${totalFailed} 件`)
+
+  if (totalFailed > 0) {
+    console.log(`\n※ 失敗したレシピはリトライ回数がインクリメントされました。`)
+    console.log(`  ${MAX_RETRY_COUNT}回失敗すると処理対象から除外されます。`)
+  }
 }
 
 main().catch((err) => {

--- a/scripts/setup-cron.ts
+++ b/scripts/setup-cron.ts
@@ -1,0 +1,198 @@
+/**
+ * pg_cron ジョブセットアップスクリプト
+ *
+ * 埋め込み生成用の cron ジョブを設定する。
+ *
+ * 使い方:
+ *   npx tsx scripts/setup-cron.ts --env=staging
+ *   npx tsx scripts/setup-cron.ts --env=production
+ *
+ * 設定されるジョブ:
+ *   1. generate-embeddings: 5分毎に Edge Function を呼び出し
+ *   2. cleanup-cron-logs: 毎日深夜に古いログを削除
+ */
+
+import { readFileSync, existsSync } from 'fs'
+import { createClient } from '@supabase/supabase-js'
+
+// 環境引数を解析
+const envArg = process.argv.find((arg) => arg.startsWith('--env='))
+if (!envArg) {
+  console.error('エラー: --env=staging または --env=production を指定してください')
+  process.exit(1)
+}
+
+const envName = envArg.split('=')[1]
+if (!['staging', 'production'].includes(envName)) {
+  console.error('エラー: 環境は staging または production を指定してください')
+  process.exit(1)
+}
+
+const envFilePath = `.env.${envName}`
+
+if (!existsSync(envFilePath)) {
+  console.error(`エラー: ${envFilePath} が見つかりません`)
+  process.exit(1)
+}
+
+console.log(`環境: ${envName} (${envFilePath})\n`)
+
+// 環境変数ファイルを読み込み
+const envFile = readFileSync(envFilePath, 'utf-8')
+for (const line of envFile.split('\n')) {
+  const match = line.match(/^([^#][^=]*)=(.*)$/)
+  if (match) {
+    process.env[match[1].trim()] = match[2].trim()
+  }
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SECRET_KEY
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('エラー: NEXT_PUBLIC_SUPABASE_URL と SUPABASE_SECRET_KEY が必要です')
+  process.exit(1)
+}
+
+// project-ref を URL から抽出
+const projectRef = supabaseUrl.match(/https:\/\/([^.]+)\.supabase\.co/)?.[1]
+if (!projectRef) {
+  console.error('エラー: Supabase URL から project-ref を抽出できません')
+  process.exit(1)
+}
+
+const edgeFunctionUrl = `${supabaseUrl}/functions/v1/generate-embeddings`
+
+console.log(`Project Ref: ${projectRef}`)
+console.log(`Edge Function URL: ${edgeFunctionUrl}`)
+console.log('')
+
+// Supabase クライアント作成
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+async function setupCronJobs() {
+  console.log('=== pg_cron ジョブセットアップ開始 ===\n')
+
+  // 1. 拡張機能の確認
+  console.log('1. 拡張機能の確認...')
+
+  await supabase.rpc('pg_cron_check', {}).maybeSingle()
+  // エラーは無視（関数がない場合もある）
+
+  // 2. 既存ジョブの削除（あれば）
+  console.log('2. 既存ジョブの確認と削除...')
+
+  const jobNames = ['generate-embeddings', 'cleanup-cron-logs']
+
+  for (const jobName of jobNames) {
+    const { error } = await supabase.rpc('cron_unschedule', { job_name: jobName }).maybeSingle()
+    if (!error) {
+      console.log(`   既存ジョブ "${jobName}" を削除しました`)
+    }
+  }
+
+  // 3. 埋め込み生成ジョブの作成
+  console.log('3. 埋め込み生成ジョブの作成...')
+
+  const embedJobSql = `
+    SELECT cron.schedule(
+      'generate-embeddings',
+      '*/5 * * * *',
+      $$
+      SELECT net.http_post(
+        url := '${edgeFunctionUrl}',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ${supabaseKey}'
+        ),
+        body := '{}'::jsonb
+      ) AS request_id;
+      $$
+    );
+  `
+
+  const { error: embedJobError } = await supabase.rpc('exec_sql', { sql: embedJobSql })
+
+  if (embedJobError) {
+    // exec_sql RPC がない場合は直接 SQL 実行を試みる
+    console.log('   RPC経由での実行に失敗、直接SQLを実行します...')
+
+    const { error: directError } = await supabase.from('_exec').select('*').limit(0)
+    if (directError) {
+      console.error('   エラー: ジョブの作成に失敗しました')
+      console.error('   Supabase ダッシュボードの SQL Editor で以下を実行してください:')
+      console.log('')
+      console.log(embedJobSql)
+      console.log('')
+    }
+  } else {
+    console.log('   ✅ generate-embeddings ジョブを作成しました（5分毎）')
+  }
+
+  // 4. ログクリーンアップジョブの作成
+  console.log('4. ログクリーンアップジョブの作成...')
+
+  const cleanupJobSql = `
+    SELECT cron.schedule(
+      'cleanup-cron-logs',
+      '0 0 * * *',
+      $$DELETE FROM cron.job_run_details WHERE end_time < now() - interval '7 days'$$
+    );
+  `
+
+  const { error: cleanupJobError } = await supabase.rpc('exec_sql', { sql: cleanupJobSql })
+
+  if (cleanupJobError) {
+    console.log('   Supabase ダッシュボードの SQL Editor で以下を実行してください:')
+    console.log('')
+    console.log(cleanupJobSql)
+    console.log('')
+  } else {
+    console.log('   ✅ cleanup-cron-logs ジョブを作成しました（毎日深夜）')
+  }
+
+  // 5. 手動実行用の SQL を出力
+  console.log('\n=== 手動セットアップ用 SQL ===')
+  console.log('Supabase ダッシュボードの SQL Editor で以下を実行してください:\n')
+
+  console.log('-- 拡張機能の有効化（未有効の場合）')
+  console.log('CREATE EXTENSION IF NOT EXISTS pg_net;')
+  console.log('CREATE EXTENSION IF NOT EXISTS pg_cron;')
+  console.log('')
+
+  console.log('-- 埋め込み生成ジョブ（5分毎）')
+  console.log(`SELECT cron.schedule(
+  'generate-embeddings',
+  '*/5 * * * *',
+  $$
+  SELECT net.http_post(
+    url := '${edgeFunctionUrl}',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ${supabaseKey}'
+    ),
+    body := '{}'::jsonb
+  ) AS request_id;
+  $$
+);`)
+  console.log('')
+
+  console.log('-- ログクリーンアップジョブ（毎日深夜）')
+  console.log(`SELECT cron.schedule(
+  'cleanup-cron-logs',
+  '0 0 * * *',
+  $$DELETE FROM cron.job_run_details WHERE end_time < now() - interval '7 days'$$
+);`)
+  console.log('')
+
+  console.log('-- ジョブ一覧の確認')
+  console.log('SELECT * FROM cron.job;')
+  console.log('')
+
+  console.log('=== セットアップ完了 ===')
+}
+
+setupCronJobs().catch((err) => {
+  console.error('セットアップエラー:', err)
+  process.exit(1)
+})

--- a/src/lib/db/queries/recipes.ts
+++ b/src/lib/db/queries/recipes.ts
@@ -2,7 +2,7 @@ import { SupabaseClient } from '@supabase/supabase-js'
 import { supabase, createServerClient } from '@/lib/db/client'
 import type { Database, Tables, TablesInsert } from '@/types/database'
 import type { SortOrder, RecipeWithIngredients, RecipeIngredient, CreateRecipeInput } from '@/types/recipe'
-import { generateAndSaveEmbedding, getVectorSearchIds } from './recipe-embedding'
+import { getVectorSearchIds } from './recipe-embedding'
 
 const MIN_ILIKE_RESULTS = 3
 
@@ -238,10 +238,7 @@ export async function createRecipe(input: CreateRecipeInput): Promise<{ data: Cr
 
     await insertRecipeIngredients(client, recipe.id, input.ingredientIds)
 
-    // 埋め込み生成（非同期、エラーは握りつぶす）
-    generateAndSaveEmbedding(client, recipe.id, input.title).catch((err) => {
-      console.error('[createRecipe] Embedding generation failed:', err)
-    })
+    // 埋め込みは pg_cron + Edge Function でバッチ生成される（title_embedding = NULL で保存）
 
     return { data: { id: recipe.id }, error: null }
   } catch (err: unknown) {

--- a/supabase/functions/generate-embeddings/index.ts
+++ b/supabase/functions/generate-embeddings/index.ts
@@ -1,0 +1,200 @@
+/**
+ * 埋め込み生成 Edge Function
+ *
+ * pg_cron から定期的に呼び出され、title_embedding が NULL のレシピに
+ * 埋め込みベクトルを生成して保存する。
+ *
+ * リトライ制限:
+ *   - embedding_retry_count が MAX_RETRY_COUNT 未満のレシピのみ処理
+ *   - 失敗時はリトライ回数をインクリメント
+ *
+ * 環境変数:
+ *   - SUPABASE_URL: 自動設定
+ *   - SUPABASE_SERVICE_ROLE_KEY: 自動設定
+ *   - GOOGLE_GENERATIVE_AI_API_KEY: 手動で Secrets に設定
+ */
+
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+const BATCH_SIZE = 100
+const EMBEDDING_MODEL = 'gemini-embedding-001'
+const MAX_RETRY_COUNT = 3
+
+interface Recipe {
+  id: string
+  title: string
+  embedding_retry_count: number
+}
+
+interface EmbedRequest {
+  model: string
+  content: { parts: { text: string }[] }
+}
+
+interface EmbedResponse {
+  embeddings: { values: number[] }[]
+}
+
+/**
+ * Google Gemini Embedding API を直接呼び出して埋め込みを生成
+ */
+async function generateEmbeddings(
+  texts: string[],
+  apiKey: string
+): Promise<(number[] | null)[]> {
+  if (texts.length === 0) return []
+
+  const requests: EmbedRequest[] = texts.map((text) => ({
+    model: `models/${EMBEDDING_MODEL}`,
+    content: { parts: [{ text: text || ' ' }] }, // 空文字対策
+  }))
+
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${EMBEDDING_MODEL}:batchEmbedContents?key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requests }),
+    }
+  )
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`Embedding API error: ${response.status} - ${error}`)
+  }
+
+  const data = (await response.json()) as EmbedResponse
+  return data.embeddings.map((e) => e.values)
+}
+
+/**
+ * 失敗したレシピのリトライ回数をインクリメント
+ */
+async function incrementRetryCount(
+  supabase: ReturnType<typeof createClient>,
+  recipeId: string,
+  currentCount: number
+): Promise<void> {
+  const { error } = await supabase
+    .from('recipes')
+    .update({ embedding_retry_count: currentCount + 1 })
+    .eq('id', recipeId)
+
+  if (error) {
+    console.error(`Failed to increment retry count for ${recipeId}:`, error)
+  }
+}
+
+Deno.serve(async () => {
+  try {
+    // 環境変数の取得
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+    const geminiApiKey = Deno.env.get('GOOGLE_GENERATIVE_AI_API_KEY')
+
+    if (!supabaseUrl || !supabaseKey) {
+      return new Response(
+        JSON.stringify({ error: 'Missing Supabase credentials' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    if (!geminiApiKey) {
+      return new Response(
+        JSON.stringify({ error: 'Missing GOOGLE_GENERATIVE_AI_API_KEY' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Supabase クライアント作成
+    const supabase = createClient(supabaseUrl, supabaseKey)
+
+    // 埋め込みが未生成かつリトライ上限に達していないレシピを取得
+    const { data: recipes, error: fetchError } = await supabase
+      .from('recipes')
+      .select('id, title, embedding_retry_count')
+      .is('title_embedding', null)
+      .lt('embedding_retry_count', MAX_RETRY_COUNT)
+      .limit(BATCH_SIZE)
+
+    if (fetchError) {
+      throw new Error(`Failed to fetch recipes: ${fetchError.message}`)
+    }
+
+    if (!recipes || recipes.length === 0) {
+      return new Response(
+        JSON.stringify({ message: 'No recipes to process', processed: 0 }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const typedRecipes = recipes as Recipe[]
+
+    // バッチで埋め込み生成（1回の API 呼び出し）
+    let embeddings: (number[] | null)[]
+    try {
+      embeddings = await generateEmbeddings(
+        typedRecipes.map((r) => r.title),
+        geminiApiKey
+      )
+    } catch (apiError) {
+      // API 全体が失敗した場合、全レシピのリトライ回数をインクリメント
+      console.error('Embedding API failed:', apiError)
+      for (const recipe of typedRecipes) {
+        await incrementRetryCount(supabase, recipe.id, recipe.embedding_retry_count)
+      }
+      throw apiError
+    }
+
+    // 各レシピに埋め込みを保存
+    let succeeded = 0
+    let failed = 0
+
+    for (let i = 0; i < typedRecipes.length; i++) {
+      const recipe = typedRecipes[i]
+      const embedding = embeddings[i]
+
+      if (!embedding) {
+        // 個別の埋め込み生成が失敗した場合
+        await incrementRetryCount(supabase, recipe.id, recipe.embedding_retry_count)
+        failed++
+        continue
+      }
+
+      const { error: updateError } = await supabase
+        .from('recipes')
+        .update({
+          title_embedding: JSON.stringify(embedding),
+          embedding_generated_at: new Date().toISOString(),
+          embedding_retry_count: 0, // 成功したらリセット
+        })
+        .eq('id', recipe.id)
+
+      if (updateError) {
+        console.error(`Failed to save embedding for ${recipe.id}:`, updateError)
+        await incrementRetryCount(supabase, recipe.id, recipe.embedding_retry_count)
+        failed++
+      } else {
+        succeeded++
+      }
+    }
+
+    return new Response(
+      JSON.stringify({
+        message: 'Embedding generation completed',
+        processed: typedRecipes.length,
+        succeeded,
+        failed,
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  } catch (error) {
+    console.error('Edge Function error:', error)
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+})

--- a/supabase/migrations/20260211000000_add_embedding_retry_count.sql
+++ b/supabase/migrations/20260211000000_add_embedding_retry_count.sql
@@ -1,0 +1,8 @@
+-- 埋め込み生成のリトライ回数を記録するカラムを追加
+-- 一定回数失敗したレシピは処理対象から除外する
+
+ALTER TABLE recipes
+ADD COLUMN embedding_retry_count INTEGER DEFAULT 0;
+
+-- リトライ回数が上限に達していないレシピのみを対象にするためのコメント
+COMMENT ON COLUMN recipes.embedding_retry_count IS '埋め込み生成の失敗回数。3回以上で処理対象から除外';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "scripts"]
+  "exclude": ["node_modules", "scripts", "supabase/functions"]
 }


### PR DESCRIPTION
## Summary

- レシピ作成時の即時埋め込み生成を廃止し、バッチ処理方式に移行
- Supabase Edge Function + pg_cron で5分毎にバッチ処理
- リトライ回数制限（3回）で無限リトライを防止

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `src/lib/db/queries/recipes.ts` | 即時埋め込み生成を削除 |
| `package.json` | `test:recipe:with-embeddings` スクリプト追加 |
| `supabase/functions/generate-embeddings/index.ts` | Edge Function 新規作成 |
| `scripts/setup-cron.ts` | cron セットアップスクリプト新規作成 |
| `scripts/backfill-embeddings.ts` | リトライロジック追加 |
| `.github/workflows/supabase-functions.yml` | Edge Function 自動デプロイ |
| `supabase/migrations/20260211000000_add_embedding_retry_count.sql` | リトライ回数カラム追加 |

## Benefits

- API 呼び出し回数を最大 100分の1 に削減（バッチ処理）
- レートリミット回避（5分毎のスケジュール実行）
- 無限リトライ防止（3回失敗でスキップ）

## Test plan

- [ ] ローカルで `npm run test:recipe:with-embeddings` を実行
- [ ] ステージングに Edge Function をデプロイ
- [ ] Supabase ダッシュボードで cron ジョブを設定
- [ ] 埋め込み生成が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)