### PR TITLE
fix: 全件表示時は「一覧をアプリで見る」ボタンを非表示にする

### DIFF
--- a/src/lib/line/flex-message.ts
+++ b/src/lib/line/flex-message.ts
@@ -154,6 +154,7 @@ export function createVerticalListMessage(
   listUrl: string,
   totalCount: number
 ): FlexMessage {
+  const hasMore = recipes.length < totalCount
   return {
     type: 'flex',
     altText: `${totalCount}件のレシピが見つかりました`,
@@ -166,13 +167,15 @@ export function createVerticalListMessage(
         contents: [{ type: 'text', text: `🔍 ${totalCount}件見つかりました`, weight: 'bold', size: 'md' }],
       },
       body: { type: 'box', layout: 'vertical', spacing: 'none', paddingAll: 'none', contents: buildListItems(recipes) },
-      footer: {
-        type: 'box',
-        layout: 'vertical',
-        contents: [
-          { type: 'button', action: { type: 'uri', label: '📖 一覧をアプリで見る', uri: listUrl }, style: 'primary', color: COLORS.primary },
-        ],
-      },
+      ...(hasMore && {
+        footer: {
+          type: 'box',
+          layout: 'vertical',
+          contents: [
+            { type: 'button', action: { type: 'uri', label: '📖 一覧をアプリで見る', uri: listUrl }, style: 'primary', color: COLORS.primary },
+          ],
+        },
+      }),
     },
   }
 }


### PR DESCRIPTION
## Summary

- 検索結果が5件以下（全件表示）のときはフッターボタンを非表示
- 6件以上ある場合のみ表示して LIFF へ誘導する

## Test plan

- [ ] 検索結果が5件以下 → フッターボタンなし
- [ ] 検索結果が6件以上 → 「一覧をアプリで見る」ボタンあり

🤖 Generated with [Claude Code](https://claude.com/claude-code)