### PR TITLE
fix: レシピ登録時に cooking_time_minutes が保存されないバグを修正

### DIFF
--- a/scripts/test-recipe-registration.ts
+++ b/scripts/test-recipe-registration.ts
@@ -32,6 +32,7 @@ interface ParsedRecipe {
   imageUrl: string
   ingredientIds: string[]
   memo: string
+  cookingTimeMinutes?: number | null
 }
 
 interface Recipe {
@@ -146,6 +147,7 @@ async function registerRecipe(
       imageUrl: parsed.imageUrl,
       ingredientIds: parsed.ingredientIds,
       memo: parsed.memo,
+      cookingTimeMinutes: parsed.cookingTimeMinutes ?? null,
     }),
   })
 

--- a/src/lib/line/url-handler.ts
+++ b/src/lib/line/url-handler.ts
@@ -53,6 +53,7 @@ async function saveRecipe(lineUserId: string, url: string): Promise<{ success: b
     imageUrl: parsed.imageUrl,
     ingredientIds: parsed.ingredientIds,
     memo: parsed.memo,
+    cookingTimeMinutes: parsed.cookingTimeMinutes ?? null,
   })
 
   if (error) {


### PR DESCRIPTION
## Summary

- LINE Bot 経由のレシピ登録（`url-handler.ts`）で `cookingTimeMinutes` を `createRecipe` に渡していなかった
- テストスクリプト（`test-recipe-registration.ts`）も同様に未渡しで、かつローカルの `ParsedRecipe` 型定義が古かった

## 影響

- これまで登録した全レシピの `cooking_time_minutes` が NULL になっている
- 修正後に登録するレシピから正しく保存される
- 既存レシピは再登録が必要（バックフィルは別途検討）

## Test plan

- [x] Nadia URL で `test:recipe` を実行 → `cooking_time_minutes: 15` が DB に保存された
- [x] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)