### PR TITLE
feat: 材料少なめカードに材料数バッジと温かいヘッダーメッセージを追加

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,31 +1,25 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-02-27 (クイックリプライ関連の修正・バグ修正 PR #11〜#14 マージ済み)
+2026-02-28 (view_count が記録されないバグ修正・after() 対応)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **一般公開準備完了**
 
 ## 直近の完了タスク
-- [x] **「探す」案内文改善・お気に入り除去（PR #14）**
-  - キーワード検索の説明を先に表示
-  - Quick Reply を3択（よく見る / 材料少なめ / 時短）に整理
-  - お気に入りは favorites epic ごと保留
-- [x] **cooking_time_minutes 保存バグ修正（PR #13）**
-  - LINE Bot・テストスクリプト両方で `cookingTimeMinutes` を渡し忘れていた
-- [x] **「よく作る」→「よく見る」リネーム（PR #12）**
-- [x] **「探す」クイックリプライ実装（PR #11）**
-  - 「探す」→ Quick Reply 3択（よく見る / 材料少なめ / 時短）
-  - RPC関数追加（ingredients_raw 配列長 / cooking_time_minutes）
-  - category-handler.ts・url-handler.ts を新規作成
-- [x] **「最近見た」「よく見る」レシピ機能を追加**
-- [x] **cooking_time_minutes 実装（PR #10 マージ済み）**（前セッション）
+- [x] **view_count が記録されないバグ修正**
+  - Vercel サーバーレス関数はレスポンス返却後に終了するため fire-and-forget が完走しなかった
+  - `GET /api/track/recipe/[id]` の `recordRecipeView` 呼び出しを `after()` でラップ（Next.js 15.1+）
+  - `replyTest` のカード URL も `/api/track/recipe/[id]` 経由に修正（直リンクだったため view_count が増えなかった）
+- [x] **end-session スキル更新**（バックログ関連実装時の更新タイミングを明確化）
+- [x] **「探す」案内文改善・お気に入り除去（PR #14）**（前セッション）
+- [x] **cooking_time_minutes 保存バグ修正（PR #13）**（前セッション）
 
 ## 進行中のタスク
 （なし）
 
 ## 次にやること（優先度順）
-- [ ] **LINE 実機確認**（「探す」クイックリプライ動作テスト）
+- [ ] **LINE 実機確認**（view_count 修正後の動作確認）
 - [ ] **既存レシピの cooking_time_minutes バックフィル**（20件全部 NULL のため）
 - [ ] **本番環境のSupabaseプロジェクト作成**
   - **東京リージョン（Northeast Asia - Tokyo）で作成すること**
@@ -70,10 +64,11 @@
 
 ## コミット履歴（直近）
 ```
-7a211d4 fix: 「探す」の案内文を改善・お気に入りをQuick Replyから除去
-87b55ea fix: レシピ登録時に cooking_time_minutes が保存されないバグを修正
-bf59fe9 fix: クイックリプライの「よく作る」を「よく見る」に変更
-2b46123 feat: 「探す」キーワードでカテゴリ選択クイックリプライを追加
+aa75389 fix: view_countが記録されないバグを修正
+01cd25e docs: バックログを更新（search-ux完了・favorites保留）
+890e1f5 docs: SESSION.md を更新（PR #11〜#14 完了）
+7a211d4 Merge pull request #14 from mktu/feature/improve-search-prompt
+9135a56 fix: 「探す」の案内文を改善・お気に入りをQuick Replyから除去
 ```
 
 ## GitHubリポジトリ

--- a/src/lib/line/category-handler.ts
+++ b/src/lib/line/category-handler.ts
@@ -126,7 +126,22 @@ export async function handleFewIngredients(
       await replyText(client, replyToken, 'レシピがまだ登録されていません。\nURLを送ってレシピを保存しましょう！')
       return
     }
-    await replyWithRecipes(client, replyToken, recipes, '📦 材料少なめレシピ')
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ''
+    const cards: RecipeCardData[] = recipes.map((r) => ({
+      title: r.title,
+      url: `${baseUrl}/api/track/recipe/${r.id}`,
+      imageUrl: r.imageUrl,
+      sourceName: r.sourceName,
+      ingredientCount: r.ingredientCount,
+    }))
+    const counts = recipes.flatMap((r) => (r.ingredientCount != null ? [r.ingredientCount] : []))
+    const maxCount = counts.length > 0 ? Math.max(...counts) : null
+    const headerText = maxCount != null ? `📦 材料${maxCount}品以下のレシピに絞りました！` : '📦 材料少なめレシピ'
+    const liffId = process.env.NEXT_PUBLIC_LIFF_ID || ''
+    await client.replyMessage({
+      replyToken,
+      messages: [createVerticalListMessage(cards, `https://liff.line.me/${liffId}`, cards.length, headerText)],
+    })
   } catch (err) {
     console.error('[LINE Webhook] handleFewIngredients error:', err)
     await replyText(client, replyToken, 'レシピの取得中にエラーが発生しました。')

--- a/src/lib/line/flex-message.ts
+++ b/src/lib/line/flex-message.ts
@@ -5,6 +5,7 @@ export interface RecipeCardData {
   url: string
   imageUrl?: string | null
   sourceName?: string | null
+  ingredientCount?: number | null
 }
 
 type FlexMessage = messagingApi.FlexMessage
@@ -125,6 +126,9 @@ function createListItemBox(recipe: RecipeCardData): messagingApi.FlexBox {
   ]
   if (recipe.sourceName) {
     textContents.push({ type: 'text', text: recipe.sourceName, size: 'xs', color: COLORS.textMuted, margin: 'sm' })
+  }
+  if (recipe.ingredientCount != null) {
+    textContents.push({ type: 'text', text: `材料 ${recipe.ingredientCount}品`, size: 'xs', color: COLORS.primary, margin: 'sm' })
   }
   return {
     type: 'box',

--- a/src/lib/line/search-recipes.ts
+++ b/src/lib/line/search-recipes.ts
@@ -10,6 +10,7 @@ export interface SearchRecipeResult {
   url: string
   imageUrl: string | null
   sourceName: string | null
+  ingredientCount?: number | null
 }
 
 /**
@@ -138,7 +139,14 @@ export async function fetchFewIngredientsForBot(lineUserId: string, limit = 5): 
   if (!user) return []
 
   const { data } = await supabase.rpc('get_recipes_few_ingredients', { p_user_id: user.id, p_limit: limit })
-  return (data ?? []).map(toResult)
+  return (data ?? []).map((r) => ({
+    id: r.id,
+    title: r.title,
+    url: r.url,
+    imageUrl: r.image_url,
+    sourceName: r.source_name,
+    ingredientCount: r.ingredient_count,
+  }))
 }
 
 /** 時短レシピ（cooking_time_minutes ASC、NULL除外） */

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -273,6 +273,7 @@ export type Database = {
         Returns: {
           id: string
           image_url: string
+          ingredient_count: number
           source_name: string
           title: string
           url: string

--- a/supabase/migrations/20260228000000_update_few_ingredients_rpc.sql
+++ b/supabase/migrations/20260228000000_update_few_ingredients_rpc.sql
@@ -1,0 +1,35 @@
+-- 材料少なめRPC: ingredient_count を返すように更新（戻り型変更のため DROP → CREATE）
+DROP FUNCTION IF EXISTS get_recipes_few_ingredients(UUID, INTEGER);
+
+CREATE OR REPLACE FUNCTION get_recipes_few_ingredients(
+  p_user_id UUID,
+  p_limit INTEGER DEFAULT 5
+)
+RETURNS TABLE (
+  id UUID,
+  title TEXT,
+  url TEXT,
+  image_url TEXT,
+  source_name TEXT,
+  ingredient_count INTEGER
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT
+    r.id,
+    r.title,
+    r.url,
+    r.image_url,
+    r.source_name,
+    jsonb_array_length(r.ingredients_raw) AS ingredient_count
+  FROM recipes r
+  WHERE r.user_id = p_user_id
+    AND r.ingredients_raw IS NOT NULL
+  ORDER BY ingredient_count ASC
+  LIMIT p_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_recipes_few_ingredients(UUID, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_recipes_few_ingredients(UUID, INTEGER) TO service_role;


### PR DESCRIPTION
## Summary

- 材料少なめレシピの各カードに「材料 X品」をアンバー色で表示し、なぜ選ばれたかがひと目でわかるように改善
- ヘッダーメッセージを `📦 材料少なめレシピ` から `📦 材料X品以下のレシピに絞りました！` に変更し、選定基準を明示
- SQL RPC (`get_recipes_few_ingredients`) に `ingredient_count` カラムを追加、`ingredients_raw IS NOT NULL` のレシピのみ対象に

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `supabase/migrations/20260228000000_update_few_ingredients_rpc.sql` | DROP→再作成。`ingredient_count INTEGER` を返すよう更新 |
| `src/types/database.ts` | 型定義を再生成 |
| `src/lib/line/search-recipes.ts` | `SearchRecipeResult` に `ingredientCount` 追加 |
| `src/lib/line/flex-message.ts` | `RecipeCardData` に `ingredientCount` 追加、カードに表示 |
| `src/lib/line/category-handler.ts` | 温かいヘッダーメッセージを生成するロジックに更新 |

## Test plan

- [ ] `材料少なめ` と送信し「📦 材料X品以下のレシピに絞りました！」が表示されることを確認
- [ ] 各カードに「材料 X品」が表示されることを確認
- [ ] `ingredients_raw` が NULL のレシピが除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)