### PR TITLE
fix: LINEカードの時短・材料少なめで両フィールドを表示し横並びに変更

### DIFF
--- a/src/lib/line/category-handler.ts
+++ b/src/lib/line/category-handler.ts
@@ -119,6 +119,7 @@ export async function handleShortCookingTime(
       imageUrl: r.imageUrl,
       sourceName: r.sourceName,
       cookingTimeMinutes: r.cookingTimeMinutes,
+      ingredientCount: r.ingredientCount,
     }))
     const headerText = '⏱ 短時間で作れるレシピ'
     const liffUrl = `https://liff.line.me/${liffId}?sort=shortest_cooking`
@@ -152,6 +153,7 @@ export async function handleFewIngredients(
       imageUrl: r.imageUrl,
       sourceName: r.sourceName,
       ingredientCount: r.ingredientCount,
+      cookingTimeMinutes: r.cookingTimeMinutes,
     }))
     const headerText = '📦 材料少なめで作れるレシピ'
     const liffUrl = `https://liff.line.me/${liffId}?sort=fewest_ingredients`

--- a/src/lib/line/flex-message.ts
+++ b/src/lib/line/flex-message.ts
@@ -136,10 +136,15 @@ function createListItemBox(recipe: RecipeCardData): messagingApi.FlexBox {
   if (recipe.sourceName) {
     textContents.push({ type: 'text', text: recipe.sourceName, size: 'xs', color: COLORS.textMuted, margin: 'sm' })
   }
-  const countText = recipe.ingredientCount != null ? `${recipe.ingredientCount}品` : '-'
-  textContents.push({ type: 'text', text: `🍴 ${countText}`, size: 'xs', color: COLORS.primary, margin: 'sm' })
   const timeText = recipe.cookingTimeMinutes != null ? `${recipe.cookingTimeMinutes}分` : '-'
-  textContents.push({ type: 'text', text: `⏱ ${timeText}`, size: 'xs', color: COLORS.primary, margin: 'sm' })
+  const countText = recipe.ingredientCount != null ? `${recipe.ingredientCount}品` : '-'
+  textContents.push({
+    type: 'box', layout: 'horizontal', margin: 'sm',
+    contents: [
+      { type: 'text', text: `⏱ ${timeText}`, size: 'xs', color: COLORS.primary, flex: 1 },
+      { type: 'text', text: `🍴 ${countText}`, size: 'xs', color: COLORS.primary, flex: 1 },
+    ],
+  })
   return {
     type: 'box',
     layout: 'horizontal',

--- a/src/lib/line/search-recipes.ts
+++ b/src/lib/line/search-recipes.ts
@@ -147,6 +147,7 @@ export async function fetchFewIngredientsForBot(lineUserId: string, limit = 5): 
     imageUrl: r.image_url,
     sourceName: r.source_name,
     ingredientCount: r.ingredient_count,
+    cookingTimeMinutes: r.cooking_time_minutes,
   }))
 }
 
@@ -164,6 +165,7 @@ export async function fetchShortCookingTimeForBot(lineUserId: string, limit = 5)
     imageUrl: r.image_url,
     sourceName: r.source_name,
     cookingTimeMinutes: r.cooking_time_minutes,
+    ingredientCount: r.ingredient_count,
   }))
 }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -271,6 +271,7 @@ export type Database = {
       get_recipes_few_ingredients: {
         Args: { p_limit?: number; p_user_id: string }
         Returns: {
+          cooking_time_minutes: number
           id: string
           image_url: string
           ingredient_count: number
@@ -282,12 +283,13 @@ export type Database = {
       get_recipes_short_cooking_time: {
         Args: { p_limit?: number; p_user_id: string }
         Returns: {
+          cooking_time_minutes: number
           id: string
           image_url: string
+          ingredient_count: number
           source_name: string
           title: string
           url: string
-          cooking_time_minutes: number
         }[]
       }
       get_unmatched_ingredient_counts: {

--- a/supabase/migrations/20260304000000_add_cross_fields_to_category_rpcs.sql
+++ b/supabase/migrations/20260304000000_add_cross_fields_to_category_rpcs.sql
@@ -1,0 +1,75 @@
+-- get_recipes_few_ingredients に cooking_time_minutes を追加
+DROP FUNCTION IF EXISTS get_recipes_few_ingredients(UUID, INTEGER);
+
+CREATE OR REPLACE FUNCTION get_recipes_few_ingredients(
+  p_user_id UUID,
+  p_limit INTEGER DEFAULT 5
+)
+RETURNS TABLE (
+  id UUID,
+  title TEXT,
+  url TEXT,
+  image_url TEXT,
+  source_name TEXT,
+  ingredient_count INTEGER,
+  cooking_time_minutes INTEGER
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT
+    r.id,
+    r.title,
+    r.url,
+    r.image_url,
+    r.source_name,
+    jsonb_array_length(r.ingredients_raw) AS ingredient_count,
+    r.cooking_time_minutes
+  FROM recipes r
+  WHERE r.user_id = p_user_id
+    AND r.ingredients_raw IS NOT NULL
+  ORDER BY ingredient_count ASC
+  LIMIT p_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_recipes_few_ingredients(UUID, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_recipes_few_ingredients(UUID, INTEGER) TO service_role;
+
+-- get_recipes_short_cooking_time に ingredient_count を追加
+DROP FUNCTION IF EXISTS get_recipes_short_cooking_time(UUID, INTEGER);
+
+CREATE OR REPLACE FUNCTION get_recipes_short_cooking_time(
+  p_user_id UUID,
+  p_limit INTEGER DEFAULT 5
+)
+RETURNS TABLE (
+  id UUID,
+  title TEXT,
+  url TEXT,
+  image_url TEXT,
+  source_name TEXT,
+  cooking_time_minutes INTEGER,
+  ingredient_count INTEGER
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT
+    r.id,
+    r.title,
+    r.url,
+    r.image_url,
+    r.source_name,
+    r.cooking_time_minutes,
+    jsonb_array_length(r.ingredients_raw) AS ingredient_count
+  FROM recipes r
+  WHERE r.user_id = p_user_id
+    AND r.cooking_time_minutes IS NOT NULL
+  ORDER BY r.cooking_time_minutes ASC
+  LIMIT p_limit;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_recipes_short_cooking_time(UUID, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_recipes_short_cooking_time(UUID, INTEGER) TO service_role;


### PR DESCRIPTION
## Summary
- 時短カードで `ingredientCount`（材料数）が表示されていなかったバグを修正
- 材料少なめカードで `cookingTimeMinutes`（調理時間）が表示されていなかったバグを修正
- 縦リストの `⏱` と `🍴` を別行から横並び（`box/horizontal`）に変更
- RPC `get_recipes_few_ingredients` に `cooking_time_minutes` カラムを追加
- RPC `get_recipes_short_cooking_time` に `ingredient_count` カラムを追加

## Test plan
- [ ] LINE で「時短」と送信 → 各カードに `⏱ X分　🍴 X品` が横並びで表示されること
- [ ] LINE で「材料少なめ」と送信 → 各カードに `⏱ X分　🍴 X品` が横並びで表示されること
- [ ] 値がない場合は `-` が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)