### PR TITLE
feat: オンボーディング機能を追加（フォーム形式）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "ai": "^6.0.48",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "radix-ui": "^1.4.3",
@@ -6398,6 +6399,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
+        "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "schema-dts": "^1.1.5",
@@ -2633,6 +2634,29 @@
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-accordion": {
       "version": "1.2.12",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
@@ -2717,6 +2741,86 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2837,6 +2941,34 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
@@ -2933,6 +3065,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -2957,6 +3118,88 @@
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3033,6 +3276,251 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3158,6 +3646,124 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-select": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
@@ -3219,10 +3825,294 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
@@ -3296,6 +4186,24 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -8743,6 +9651,124 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/radix-ui": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react": {
       "version": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ai": "^6.0.48",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "radix-ui": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
+    "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "schema-dts": "^1.1.5",

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,9 +1,14 @@
 import { AuthWrapper } from '@/components/providers/auth-wrapper'
+import { OnboardingGuard } from '@/components/providers/onboarding-guard'
 
 export default function ProtectedLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  return <AuthWrapper>{children}</AuthWrapper>
+  return (
+    <AuthWrapper>
+      <OnboardingGuard>{children}</OnboardingGuard>
+    </AuthWrapper>
+  )
 }

--- a/src/app/(protected)/onboarding/page.tsx
+++ b/src/app/(protected)/onboarding/page.tsx
@@ -1,0 +1,5 @@
+import { PreferencesForm } from '@/components/features/onboarding/preferences-form'
+
+export default function OnboardingPage() {
+  return <PreferencesForm />
+}

--- a/src/app/(protected)/onboarding/result/page.tsx
+++ b/src/app/(protected)/onboarding/result/page.tsx
@@ -1,0 +1,5 @@
+import { RecipeCandidates } from '@/components/features/onboarding/recipe-candidates'
+
+export default function OnboardingResultPage() {
+  return <RecipeCandidates />
+}

--- a/src/app/api/auth/onboarding-status/route.ts
+++ b/src/app/api/auth/onboarding-status/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/db/client'
+
+export async function GET(request: NextRequest) {
+  const lineUserId = request.nextUrl.searchParams.get('lineUserId')
+
+  if (!lineUserId) {
+    return NextResponse.json({ error: 'Missing lineUserId' }, { status: 400 })
+  }
+
+  const supabase = createServerClient()
+
+  const { data } = await supabase
+    .from('users')
+    .select('onboarding_completed_at')
+    .eq('line_user_id', lineUserId)
+    .maybeSingle()
+
+  const completed = data?.onboarding_completed_at != null
+
+  return NextResponse.json({ completed })
+}

--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createServerClient } from '@/lib/db/client'
-import { createRecipe } from '@/lib/db/queries/recipes'
-import type { CreateRecipeInput } from '@/types/recipe'
+import type { Json, TablesInsert } from '@/types/database'
 
 interface RecipeCandidate {
   url: string
@@ -24,24 +23,31 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Missing lineUserId' }, { status: 400 })
   }
 
-  // 選択されたレシピを順次登録
-  for (const candidate of selectedCandidates) {
-    const input: CreateRecipeInput = {
-      lineUserId,
-      url: candidate.url,
-      title: candidate.title,
-      imageUrl: candidate.imageUrl,
-      ingredientIds: [],
-      ingredientsRaw: candidate.ingredientsRaw ?? [],
-      cookingTimeMinutes: candidate.cookingTimeMinutes ?? null,
-    }
-    const { error } = await createRecipe(input)
+  const supabase = createServerClient()
+
+  // userId を1回だけ取得
+  const { data: user } = await supabase
+    .from('users')
+    .select('id')
+    .eq('line_user_id', lineUserId)
+    .maybeSingle()
+
+  if (user && selectedCandidates.length > 0) {
+    const rows: TablesInsert<'recipes'>[] = selectedCandidates.map((c) => ({
+      user_id: user.id,
+      url: c.url,
+      title: c.title,
+      image_url: c.imageUrl ?? null,
+      cooking_time_minutes: c.cookingTimeMinutes ?? null,
+      ingredients_raw: (c.ingredientsRaw ?? []) as unknown as Json,
+      ingredients_linked: false,
+    }))
+
+    const { error } = await supabase.from('recipes').insert(rows)
     if (error) {
-      console.error('[onboarding/complete] createRecipe error:', error)
+      console.error('[onboarding/complete] Bulk insert error:', error)
     }
   }
-
-  const supabase = createServerClient()
 
   // onboarding_completed_at を更新
   const { error: updateError } = await supabase
@@ -54,10 +60,7 @@ export async function POST(request: NextRequest) {
   }
 
   // onboarding_sessions を削除（一時データ破棄）
-  await supabase
-    .from('onboarding_sessions')
-    .delete()
-    .eq('user_id', lineUserId)
+  await supabase.from('onboarding_sessions').delete().eq('user_id', lineUserId)
 
   return NextResponse.json({ success: true })
 }

--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/db/client'
+import { createRecipe } from '@/lib/db/queries/recipes'
+import type { CreateRecipeInput } from '@/types/recipe'
+
+interface RecipeCandidate {
+  url: string
+  title: string
+  imageUrl?: string
+  cookingTimeMinutes?: number | null
+  ingredientsRaw?: { name: string; amount: string }[]
+}
+
+interface CompleteRequestBody {
+  lineUserId: string
+  selectedCandidates: RecipeCandidate[]
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json() as CompleteRequestBody
+  const { lineUserId, selectedCandidates } = body
+
+  if (!lineUserId) {
+    return NextResponse.json({ error: 'Missing lineUserId' }, { status: 400 })
+  }
+
+  // 選択されたレシピを順次登録
+  for (const candidate of selectedCandidates) {
+    const input: CreateRecipeInput = {
+      lineUserId,
+      url: candidate.url,
+      title: candidate.title,
+      imageUrl: candidate.imageUrl,
+      ingredientIds: [],
+      ingredientsRaw: candidate.ingredientsRaw ?? [],
+      cookingTimeMinutes: candidate.cookingTimeMinutes ?? null,
+    }
+    const { error } = await createRecipe(input)
+    if (error) {
+      console.error('[onboarding/complete] createRecipe error:', error)
+    }
+  }
+
+  const supabase = createServerClient()
+
+  // onboarding_completed_at を更新
+  const { error: updateError } = await supabase
+    .from('users')
+    .update({ onboarding_completed_at: new Date().toISOString() })
+    .eq('line_user_id', lineUserId)
+
+  if (updateError) {
+    console.error('[onboarding/complete] Update user error:', updateError)
+  }
+
+  // onboarding_sessions を削除（一時データ破棄）
+  await supabase
+    .from('onboarding_sessions')
+    .delete()
+    .eq('user_id', lineUserId)
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/onboarding/result/route.ts
+++ b/src/app/api/onboarding/result/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/db/client'
+
+export async function GET(request: NextRequest) {
+  const lineUserId = request.nextUrl.searchParams.get('lineUserId')
+
+  if (!lineUserId) {
+    return NextResponse.json({ error: 'Missing lineUserId' }, { status: 400 })
+  }
+
+  const supabase = createServerClient()
+
+  const { data } = await supabase
+    .from('onboarding_sessions')
+    .select('id, status, candidates, expires_at')
+    .eq('user_id', lineUserId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (!data) {
+    return NextResponse.json({ session: null })
+  }
+
+  // 期限切れチェック
+  if (data.expires_at && new Date(data.expires_at) < new Date()) {
+    return NextResponse.json({ session: null })
+  }
+
+  return NextResponse.json({
+    session: {
+      id: data.id,
+      status: data.status,
+      candidates: data.candidates,
+      expiresAt: data.expires_at,
+    },
+  })
+}

--- a/src/app/api/onboarding/start/route.ts
+++ b/src/app/api/onboarding/start/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
   }
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseKey = process.env.SUPABASE_SECRET_KEY
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (supabaseUrl && supabaseKey) {
     // 非同期で Edge Function を起動（await しない）

--- a/src/app/api/onboarding/start/route.ts
+++ b/src/app/api/onboarding/start/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/db/client'
+
+interface OnboardingPreferences {
+  searchQuery: string
+  dislikedIngredients: string[]
+  maxCookingMinutes: number | null
+}
+
+interface StartRequestBody {
+  lineUserId: string
+  preferences: OnboardingPreferences
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json() as StartRequestBody
+  const { lineUserId, preferences } = body
+
+  if (!lineUserId || !preferences?.searchQuery) {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
+  }
+
+  const supabase = createServerClient()
+
+  // 冪等性チェック: pending かつ未期限のセッションが既存なら返す
+  const { data: existing } = await supabase
+    .from('onboarding_sessions')
+    .select('id')
+    .eq('user_id', lineUserId)
+    .eq('status', 'pending')
+    .gt('expires_at', new Date().toISOString())
+    .maybeSingle()
+
+  if (existing) {
+    return NextResponse.json({ sessionId: existing.id }, { status: 202 })
+  }
+
+  const { data: session, error } = await supabase
+    .from('onboarding_sessions')
+    .insert({ user_id: lineUserId, preferences: preferences as unknown as import('@/types/database').Json })
+    .select('id')
+    .single()
+
+  if (error || !session) {
+    console.error('[onboarding/start] Insert failed:', error)
+    return NextResponse.json({ error: 'Failed to create session' }, { status: 500 })
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = process.env.SUPABASE_SECRET_KEY
+
+  if (supabaseUrl && supabaseKey) {
+    // 非同期で Edge Function を起動（await しない）
+    fetch(`${supabaseUrl}/functions/v1/onboarding-scrape`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${supabaseKey}`,
+      },
+      body: JSON.stringify({ sessionId: session.id }),
+    }).catch((err) => {
+      console.error('[onboarding/start] Edge Function kick failed:', err)
+    })
+  }
+
+  return NextResponse.json({ sessionId: session.id }, { status: 202 })
+}

--- a/src/app/api/webhook/line/route.ts
+++ b/src/app/api/webhook/line/route.ts
@@ -105,13 +105,50 @@ async function handleFollowEvent(event: WebhookEvent): Promise<void> {
 
   await ensureUser(userId)
 
-  const welcomeText = `RecipeHub へようこそ！🎉
+  const liffId = process.env.NEXT_PUBLIC_LIFF_ID
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? ''
+  const onboardingUrl = liffId
+    ? `https://liff.line.me/${liffId}/onboarding`
+    : `${appUrl}/onboarding`
 
-レシピサイトの URL をこのトークに送るだけで、食材タグつきで自動保存できます。
-
-まずは「使い方」と送ってみてください 👋`
-
-  await client.pushMessage({ to: userId, messages: [{ type: 'text', text: welcomeText }] })
+  await client.pushMessage({
+    to: userId,
+    messages: [
+      {
+        type: 'flex',
+        altText: 'RecipeHub へようこそ！まず好みのレシピを探してみましょう。',
+        contents: {
+          type: 'bubble',
+          body: {
+            type: 'box',
+            layout: 'vertical',
+            contents: [
+              { type: 'text', text: 'RecipeHub へようこそ！🍳', weight: 'bold', size: 'lg' },
+              {
+                type: 'text',
+                text: 'まず、好みに合ったレシピを一緒に探してみましょう。\n下のボタンからはじめてください👇',
+                size: 'sm',
+                color: '#666666',
+                margin: 'md',
+                wrap: true,
+              },
+            ],
+          },
+          footer: {
+            type: 'box',
+            layout: 'vertical',
+            contents: [
+              {
+                type: 'button',
+                style: 'primary',
+                action: { type: 'uri', label: 'レシピを探す', uri: onboardingUrl },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  })
 }
 
 /** メッセージイベントを処理 */

--- a/src/components/features/onboarding/ingredient-suggest-input.tsx
+++ b/src/components/features/onboarding/ingredient-suggest-input.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect, useRef, useMemo } from 'react'
 import { X } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { Command, CommandItem, CommandList } from '@/components/ui/command'
 import { supabase } from '@/lib/db/client'
 
 interface Ingredient {
@@ -40,87 +42,100 @@ function useSuggestIngredients(query: string, selected: string[]) {
 
 export function IngredientSuggestInput({ value, onChange, placeholder }: IngredientSuggestInputProps) {
   const [query, setQuery] = useState('')
-  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [open, setOpen] = useState(false)
   const [isComposing, setIsComposing] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
+  const [highlightedIndex, setHighlightedIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
   const suggestions = useSuggestIngredients(query, value)
-  const showDropdown = dropdownOpen && suggestions.length > 0
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setDropdownOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  const activeIndex = Math.min(highlightedIndex, suggestions.length - 1)
+  const showDropdown = open && suggestions.length > 0
 
   function addFromSuggestion(name: string) {
     if (value.includes(name)) return
     onChange([...value, name])
     setQuery('')
-    setDropdownOpen(false)
-  }
-
-  function removeItem(name: string) {
-    onChange(value.filter((v) => v !== name))
+    setOpen(false)
+    setHighlightedIndex(0)
   }
 
   function handleQueryChange(e: React.ChangeEvent<HTMLInputElement>) {
     setQuery(e.target.value)
-    setDropdownOpen(true)
+    setOpen(true)
+    setHighlightedIndex(0)
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    // IME確定中のEnterは無視（日本語入力対応）
-    if (e.key === 'Enter' && !isComposing) {
+    if (e.key === 'ArrowDown') {
       e.preventDefault()
-      // 完全一致優先、なければ先頭候補
-      const exact = suggestions.find((s) => s.name === query.trim())
-      const toAdd = exact ?? (suggestions.length > 0 ? suggestions[0] : null)
-      if (toAdd) addFromSuggestion(toAdd.name)
-    }
-    if (e.key === 'Backspace' && !query && value.length > 0) {
+      setHighlightedIndex((i) => Math.min(i + 1, suggestions.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlightedIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter' && !isComposing) {
+      e.preventDefault()
+      if (suggestions[activeIndex]) addFromSuggestion(suggestions[activeIndex].name)
+    } else if (e.key === 'Backspace' && !query && value.length > 0) {
       onChange(value.slice(0, -1))
+    } else if (e.key === 'Escape') {
+      setOpen(false)
     }
   }
 
   return (
-    <div ref={containerRef} className="relative">
-      <div className="flex flex-wrap gap-1 rounded-md border border-input bg-background p-2 min-h-10 focus-within:ring-1 focus-within:ring-ring">
-        {value.map((name) => (
-          <Badge key={name} variant="secondary" className="gap-1 py-0.5">
-            {name}
-            <button type="button" onClick={() => removeItem(name)} className="ml-0.5 rounded-full hover:bg-muted">
-              <X className="h-3 w-3" />
-            </button>
-          </Badge>
-        ))}
-        <Input
-          className="h-auto flex-1 min-w-24 border-0 p-0 shadow-none focus-visible:ring-0"
-          value={query}
-          onChange={handleQueryChange}
-          onKeyDown={handleKeyDown}
-          onCompositionStart={() => setIsComposing(true)}
-          onCompositionEnd={() => setIsComposing(false)}
-          placeholder={value.length === 0 ? placeholder : ''}
-        />
-      </div>
-      {showDropdown && (
-        <ul className="absolute z-10 mt-1 w-full rounded-md border border-input bg-background shadow-md">
-          {suggestions.map((s) => (
-            <li key={s.id}>
+    <div className="space-y-1.5">
+      <Popover open={showDropdown} onOpenChange={(v) => { if (!v) setOpen(false) }}>
+        <PopoverAnchor asChild>
+          <Input
+            ref={inputRef}
+            value={query}
+            onChange={handleQueryChange}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
+            placeholder={placeholder}
+          />
+        </PopoverAnchor>
+        <PopoverContent
+          className="w-(--radix-popover-anchor-width) p-0"
+          align="start"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <Command
+            shouldFilter={false}
+            value={suggestions[activeIndex]?.name ?? ''}
+            onValueChange={() => {}}
+          >
+            <CommandList>
+              {suggestions.map((s, i) => (
+                <CommandItem
+                  key={s.id}
+                  value={s.name}
+                  onMouseEnter={() => setHighlightedIndex(i)}
+                  onMouseDown={(e) => { e.preventDefault(); addFromSuggestion(s.name) }}
+                  className="data-[selected=true]:bg-muted data-[selected=true]:text-foreground cursor-pointer"
+                >
+                  {s.name}
+                </CommandItem>
+              ))}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {value.map((name) => (
+            <Badge key={name} variant="secondary" className="gap-1 py-0.5">
+              {name}
               <button
                 type="button"
-                className="w-full px-3 py-2 text-left text-sm hover:bg-accent"
-                onMouseDown={(e) => { e.preventDefault(); addFromSuggestion(s.name) }}
+                onClick={() => onChange(value.filter((v) => v !== name))}
+                className="ml-0.5 rounded-full hover:bg-muted"
               >
-                {s.name}
+                <X className="h-3 w-3" />
               </button>
-            </li>
+            </Badge>
           ))}
-        </ul>
+        </div>
       )}
     </div>
   )

--- a/src/components/features/onboarding/ingredient-suggest-input.tsx
+++ b/src/components/features/onboarding/ingredient-suggest-input.tsx
@@ -41,6 +41,7 @@ function useSuggestIngredients(query: string, selected: string[]) {
 export function IngredientSuggestInput({ value, onChange, placeholder }: IngredientSuggestInputProps) {
   const [query, setQuery] = useState('')
   const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [isComposing, setIsComposing] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const suggestions = useSuggestIngredients(query, value)
   const showDropdown = dropdownOpen && suggestions.length > 0
@@ -55,10 +56,9 @@ export function IngredientSuggestInput({ value, onChange, placeholder }: Ingredi
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  function addItem(name: string) {
-    const trimmed = name.trim()
-    if (!trimmed || value.includes(trimmed)) return
-    onChange([...value, trimmed])
+  function addFromSuggestion(name: string) {
+    if (value.includes(name)) return
+    onChange([...value, name])
     setQuery('')
     setDropdownOpen(false)
   }
@@ -73,9 +73,13 @@ export function IngredientSuggestInput({ value, onChange, placeholder }: Ingredi
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter' && query.trim()) {
+    // IME確定中のEnterは無視（日本語入力対応）
+    if (e.key === 'Enter' && !isComposing) {
       e.preventDefault()
-      addItem(query)
+      // 完全一致優先、なければ先頭候補
+      const exact = suggestions.find((s) => s.name === query.trim())
+      const toAdd = exact ?? (suggestions.length > 0 ? suggestions[0] : null)
+      if (toAdd) addFromSuggestion(toAdd.name)
     }
     if (e.key === 'Backspace' && !query && value.length > 0) {
       onChange(value.slice(0, -1))
@@ -98,6 +102,8 @@ export function IngredientSuggestInput({ value, onChange, placeholder }: Ingredi
           value={query}
           onChange={handleQueryChange}
           onKeyDown={handleKeyDown}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
           placeholder={value.length === 0 ? placeholder : ''}
         />
       </div>
@@ -108,7 +114,7 @@ export function IngredientSuggestInput({ value, onChange, placeholder }: Ingredi
               <button
                 type="button"
                 className="w-full px-3 py-2 text-left text-sm hover:bg-accent"
-                onMouseDown={(e) => { e.preventDefault(); addItem(s.name) }}
+                onMouseDown={(e) => { e.preventDefault(); addFromSuggestion(s.name) }}
               >
                 {s.name}
               </button>

--- a/src/components/features/onboarding/ingredient-suggest-input.tsx
+++ b/src/components/features/onboarding/ingredient-suggest-input.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState, useEffect, useRef, useMemo } from 'react'
+import { X } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { supabase } from '@/lib/db/client'
+
+interface Ingredient {
+  id: string
+  name: string
+}
+
+interface IngredientSuggestInputProps {
+  value: string[]
+  onChange: (value: string[]) => void
+  placeholder?: string
+}
+
+function useSuggestIngredients(query: string, selected: string[]) {
+  const [allIngredients, setAllIngredients] = useState<Ingredient[]>([])
+
+  useEffect(() => {
+    const fetchAll = async () => {
+      const { data } = await supabase.from('ingredients').select('id, name')
+      if (data) setAllIngredients(data as Ingredient[])
+    }
+    fetchAll()
+  }, [])
+
+  return useMemo(() => {
+    if (!query.trim()) return []
+    const q = query.toLowerCase()
+    const selectedSet = new Set(selected)
+    return allIngredients
+      .filter((i) => i.name.toLowerCase().includes(q) && !selectedSet.has(i.name))
+      .slice(0, 8)
+  }, [query, allIngredients, selected])
+}
+
+export function IngredientSuggestInput({ value, onChange, placeholder }: IngredientSuggestInputProps) {
+  const [query, setQuery] = useState('')
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const suggestions = useSuggestIngredients(query, value)
+  const showDropdown = dropdownOpen && suggestions.length > 0
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  function addItem(name: string) {
+    const trimmed = name.trim()
+    if (!trimmed || value.includes(trimmed)) return
+    onChange([...value, trimmed])
+    setQuery('')
+    setDropdownOpen(false)
+  }
+
+  function removeItem(name: string) {
+    onChange(value.filter((v) => v !== name))
+  }
+
+  function handleQueryChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setQuery(e.target.value)
+    setDropdownOpen(true)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' && query.trim()) {
+      e.preventDefault()
+      addItem(query)
+    }
+    if (e.key === 'Backspace' && !query && value.length > 0) {
+      onChange(value.slice(0, -1))
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="flex flex-wrap gap-1 rounded-md border border-input bg-background p-2 min-h-10 focus-within:ring-1 focus-within:ring-ring">
+        {value.map((name) => (
+          <Badge key={name} variant="secondary" className="gap-1 py-0.5">
+            {name}
+            <button type="button" onClick={() => removeItem(name)} className="ml-0.5 rounded-full hover:bg-muted">
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+        <Input
+          className="h-auto flex-1 min-w-24 border-0 p-0 shadow-none focus-visible:ring-0"
+          value={query}
+          onChange={handleQueryChange}
+          onKeyDown={handleKeyDown}
+          placeholder={value.length === 0 ? placeholder : ''}
+        />
+      </div>
+      {showDropdown && (
+        <ul className="absolute z-10 mt-1 w-full rounded-md border border-input bg-background shadow-md">
+          {suggestions.map((s) => (
+            <li key={s.id}>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left text-sm hover:bg-accent"
+                onMouseDown={(e) => { e.preventDefault(); addItem(s.name) }}
+              >
+                {s.name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/onboarding/preferences-form.tsx
+++ b/src/components/features/onboarding/preferences-form.tsx
@@ -92,7 +92,7 @@ export function PreferencesForm() {
               onChange={(v) => setForm((f) => ({ ...f, searchKeywords: v }))}
               placeholder="例: 鶏肉、パスタ、時短…"
             />
-            <p className="text-xs text-muted-foreground">Enter または候補をタップで追加</p>
+            <p className="text-xs text-muted-foreground">候補から選んでください（Enter で先頭候補を追加）</p>
           </div>
           <div className="space-y-2">
             <Label>苦手な食材（任意）</Label>

--- a/src/components/features/onboarding/preferences-form.tsx
+++ b/src/components/features/onboarding/preferences-form.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { IngredientSuggestInput } from './ingredient-suggest-input'
+import { useAuth } from '@/lib/auth'
+
+interface FormState {
+  searchKeywords: string[]
+  dislikedIngredients: string[]
+  maxCookingMinutes: string
+}
+
+export function PreferencesForm() {
+  const { user } = useAuth()
+  const router = useRouter()
+  const [form, setForm] = useState<FormState>({
+    searchKeywords: [],
+    dislikedIngredients: [],
+    maxCookingMinutes: 'none',
+  })
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!user || form.searchKeywords.length === 0) return
+    setSubmitting(true)
+
+    const maxCookingMinutes = form.maxCookingMinutes === 'none' ? null : parseInt(form.maxCookingMinutes, 10)
+    const searchQuery = form.searchKeywords.join(' ')
+
+    try {
+      const res = await fetch('/api/onboarding/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          lineUserId: user.lineUserId,
+          preferences: { searchQuery, dislikedIngredients: form.dislikedIngredients, maxCookingMinutes },
+        }),
+      })
+      if (!res.ok) throw new Error('Failed to start')
+      setSubmitted(true)
+    } catch {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleSkip() {
+    if (!user) return
+    await fetch('/api/onboarding/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lineUserId: user.lineUserId, selectedCandidates: [] }),
+    })
+    router.replace('/')
+  }
+
+  if (submitted) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center p-6 text-center">
+        <div className="max-w-sm space-y-4">
+          <p className="text-2xl">🍳</p>
+          <h2 className="text-lg font-semibold">バックグラウンドで探しています</h2>
+          <p className="text-sm text-muted-foreground">
+            完了したら LINE でお知らせします！<br />
+            見つかったら候補から登録してください。
+          </p>
+          <Button variant="outline" size="sm" onClick={() => router.replace('/onboarding/result')}>
+            結果を確認する
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-6">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="space-y-1 text-center">
+          <h1 className="text-xl font-bold">好みを教えてください</h1>
+          <p className="text-sm text-muted-foreground">あなた向けのレシピを探します</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div className="space-y-2">
+            <Label>好きな食材・料理名 <span className="text-destructive">*</span></Label>
+            <IngredientSuggestInput
+              value={form.searchKeywords}
+              onChange={(v) => setForm((f) => ({ ...f, searchKeywords: v }))}
+              placeholder="例: 鶏肉、パスタ、時短…"
+            />
+            <p className="text-xs text-muted-foreground">Enter または候補をタップで追加</p>
+          </div>
+          <div className="space-y-2">
+            <Label>苦手な食材（任意）</Label>
+            <IngredientSuggestInput
+              value={form.dislikedIngredients}
+              onChange={(v) => setForm((f) => ({ ...f, dislikedIngredients: v }))}
+              placeholder="例: セロリ、パクチー…"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>調理時間の希望</Label>
+            <Select
+              value={form.maxCookingMinutes}
+              onValueChange={(v) => setForm((f) => ({ ...f, maxCookingMinutes: v }))}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">制限なし</SelectItem>
+                <SelectItem value="30">30分以内</SelectItem>
+                <SelectItem value="20">20分以内</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={submitting || form.searchKeywords.length === 0}
+          >
+            {submitting ? '送信中…' : 'レシピを探してもらう'}
+          </Button>
+        </form>
+        <div className="text-center">
+          <button type="button" onClick={handleSkip} className="text-xs text-muted-foreground underline">
+            スキップして始める
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/onboarding/recipe-candidates.tsx
+++ b/src/components/features/onboarding/recipe-candidates.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { useAuth } from '@/lib/auth'
@@ -140,7 +141,16 @@ function CandidatesView({ candidates, submitting, onComplete, onSkip }: Candidat
   )
 }
 
+function getSiteName(url: string): string {
+  if (url.includes('delishkitchen.tv')) return 'DELISH KITCHEN'
+  if (url.includes('oceans-nadia.com')) return 'Nadia'
+  if (url.includes('kurashiru.com')) return 'クラシル'
+  if (url.includes('cookpad.com')) return 'クックパッド'
+  try { return new URL(url).hostname.replace('www.', '') } catch { return '' }
+}
+
 function CandidateCard({ candidate, checked, onToggle }: { candidate: RecipeCandidate; checked: boolean; onToggle: () => void }) {
+  const siteName = getSiteName(candidate.url)
   return (
     <div className="flex items-start gap-3 rounded-lg border p-3">
       <Checkbox id={candidate.url} checked={checked} onCheckedChange={onToggle} className="mt-1" />
@@ -150,12 +160,23 @@ function CandidateCard({ candidate, checked, onToggle }: { candidate: RecipeCand
           <img src={candidate.imageUrl} alt={candidate.title} className="h-full w-full object-cover" />
         </div>
       )}
-      <label htmlFor={candidate.url} className="flex-1 cursor-pointer space-y-0.5">
-        <p className="text-sm font-medium leading-tight">{candidate.title}</p>
-        {candidate.cookingTimeMinutes && (
-          <p className="text-xs text-muted-foreground">⏱ {candidate.cookingTimeMinutes}分</p>
-        )}
-      </label>
+      <div className="flex-1 space-y-0.5">
+        <label htmlFor={candidate.url} className="block cursor-pointer text-sm font-medium leading-tight">
+          {candidate.title}
+        </label>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {siteName && <span>{siteName}</span>}
+          {candidate.cookingTimeMinutes && <span>⏱ {candidate.cookingTimeMinutes}分</span>}
+        </div>
+        <a
+          href={candidate.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-0.5 text-xs text-primary underline"
+        >
+          元のページを見る <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
     </div>
   )
 }

--- a/src/components/features/onboarding/recipe-candidates.tsx
+++ b/src/components/features/onboarding/recipe-candidates.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import Image from 'next/image'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { useAuth } from '@/lib/auth'
+
+interface RecipeCandidate {
+  url: string
+  title: string
+  imageUrl: string
+  cookingTimeMinutes: number | null
+  ingredientsRaw: { name: string; amount: string }[]
+}
+
+interface OnboardingSession {
+  id: string
+  status: string
+  candidates: RecipeCandidate[] | null
+  expiresAt: string | null
+}
+
+type SessionState = OnboardingSession | null | undefined
+
+const POLL_INTERVAL_MS = 3000
+
+function useOnboardingSession(lineUserId: string | undefined) {
+  const [session, setSession] = useState<SessionState>(undefined)
+
+  useEffect(() => {
+    if (!lineUserId) return
+    const load = async () => {
+      const res = await fetch(`/api/onboarding/result?lineUserId=${lineUserId}`)
+      const data = await res.json() as { session: OnboardingSession | null }
+      setSession(data.session)
+    }
+    load()
+  }, [lineUserId])
+
+  useEffect(() => {
+    if (!lineUserId || !session || session.status !== 'pending') return
+    const timer = setInterval(() => {
+      const poll = async () => {
+        const res = await fetch(`/api/onboarding/result?lineUserId=${lineUserId}`)
+        const data = await res.json() as { session: OnboardingSession | null }
+        setSession(data.session)
+      }
+      poll()
+    }, POLL_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [lineUserId, session])
+
+  return session
+}
+
+export function RecipeCandidates() {
+  const { user } = useAuth()
+  const router = useRouter()
+  const session = useOnboardingSession(user?.lineUserId)
+  // null = not yet customized (all selected by default); Set = user customized
+  const [customSelected, setCustomSelected] = useState<Set<string> | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const candidates = session?.status === 'completed' ? (session.candidates ?? []) : []
+  // Default: all selected. Custom selection overrides.
+  const selected = customSelected ?? new Set(candidates.map((c) => c.url))
+
+  function toggleCandidate(url: string) {
+    const next = new Set(selected)
+    if (next.has(url)) {
+      next.delete(url)
+    } else {
+      next.add(url)
+    }
+    setCustomSelected(next)
+  }
+
+  async function handleComplete(toRegister: RecipeCandidate[]) {
+    if (!user) return
+    setSubmitting(true)
+    await fetch('/api/onboarding/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lineUserId: user.lineUserId, selectedCandidates: toRegister }),
+    })
+    router.replace('/')
+  }
+
+  if (session === undefined) return <LoadingView message="確認中..." />
+
+  if (session === null) {
+    return (
+      <CenterView>
+        <p className="text-muted-foreground">期限切れです。もう一度お試しください。</p>
+        <Button variant="outline" onClick={() => router.replace('/onboarding')}>もう一度試す</Button>
+      </CenterView>
+    )
+  }
+
+  if (session.status === 'pending') return <LoadingView message="バックグラウンドで探しています..." />
+
+  if (session.status === 'failed' || candidates.length === 0) {
+    return (
+      <CenterView>
+        <p className="text-muted-foreground">レシピが見つかりませんでした。</p>
+        <Button variant="outline" onClick={() => handleComplete([])} disabled={submitting}>スキップして始める</Button>
+      </CenterView>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col p-4">
+      <div className="mb-4 space-y-1">
+        <h1 className="text-lg font-bold">レシピ候補</h1>
+        <p className="text-sm text-muted-foreground">登録するレシピを選んでください</p>
+      </div>
+      <div className="flex-1 space-y-3">
+        {candidates.map((c) => (
+          <CandidateCard key={c.url} candidate={c} checked={selected.has(c.url)} onToggle={() => toggleCandidate(c.url)} />
+        ))}
+      </div>
+      <div className="mt-6 space-y-2">
+        <Button
+          className="w-full"
+          onClick={() => handleComplete(candidates.filter((c) => selected.has(c.url)))}
+          disabled={submitting || selected.size === 0}
+        >
+          {submitting ? '登録中…' : `まとめて登録する（${selected.size}件）`}
+        </Button>
+        <Button variant="ghost" className="w-full" onClick={() => handleComplete([])} disabled={submitting}>
+          スキップして始める
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function CandidateCard({ candidate, checked, onToggle }: { candidate: RecipeCandidate; checked: boolean; onToggle: () => void }) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border p-3">
+      <Checkbox id={candidate.url} checked={checked} onCheckedChange={onToggle} className="mt-1" />
+      {candidate.imageUrl && (
+        <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded">
+          <Image src={candidate.imageUrl} alt={candidate.title} fill className="object-cover" unoptimized />
+        </div>
+      )}
+      <label htmlFor={candidate.url} className="flex-1 cursor-pointer space-y-0.5">
+        <p className="text-sm font-medium leading-tight">{candidate.title}</p>
+        {candidate.cookingTimeMinutes && (
+          <p className="text-xs text-muted-foreground">⏱ {candidate.cookingTimeMinutes}分</p>
+        )}
+      </label>
+    </div>
+  )
+}
+
+function LoadingView({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <p className="text-muted-foreground">{message}</p>
+    </div>
+  )
+}
+
+function CenterView({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-6">
+      {children}
+    </div>
+  )
+}

--- a/src/components/features/onboarding/recipe-candidates.tsx
+++ b/src/components/features/onboarding/recipe-candidates.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { useAuth } from '@/lib/auth'
@@ -59,23 +58,9 @@ export function RecipeCandidates() {
   const { user } = useAuth()
   const router = useRouter()
   const session = useOnboardingSession(user?.lineUserId)
-  // null = not yet customized (all selected by default); Set = user customized
-  const [customSelected, setCustomSelected] = useState<Set<string> | null>(null)
   const [submitting, setSubmitting] = useState(false)
 
   const candidates = session?.status === 'completed' ? (session.candidates ?? []) : []
-  // Default: all selected. Custom selection overrides.
-  const selected = customSelected ?? new Set(candidates.map((c) => c.url))
-
-  function toggleCandidate(url: string) {
-    const next = new Set(selected)
-    if (next.has(url)) {
-      next.delete(url)
-    } else {
-      next.add(url)
-    }
-    setCustomSelected(next)
-  }
 
   async function handleComplete(toRegister: RecipeCandidate[]) {
     if (!user) return
@@ -89,7 +74,6 @@ export function RecipeCandidates() {
   }
 
   if (session === undefined) return <LoadingView message="確認中..." />
-
   if (session === null) {
     return (
       <CenterView>
@@ -98,9 +82,7 @@ export function RecipeCandidates() {
       </CenterView>
     )
   }
-
   if (session.status === 'pending') return <LoadingView message="バックグラウンドで探しています..." />
-
   if (session.status === 'failed' || candidates.length === 0) {
     return (
       <CenterView>
@@ -108,6 +90,33 @@ export function RecipeCandidates() {
         <Button variant="outline" onClick={() => handleComplete([])} disabled={submitting}>スキップして始める</Button>
       </CenterView>
     )
+  }
+
+  return (
+    <CandidatesView
+      candidates={candidates}
+      submitting={submitting}
+      onComplete={handleComplete}
+      onSkip={() => handleComplete([])}
+    />
+  )
+}
+
+interface CandidatesViewProps {
+  candidates: RecipeCandidate[]
+  submitting: boolean
+  onComplete: (selected: RecipeCandidate[]) => void
+  onSkip: () => void
+}
+
+function CandidatesView({ candidates, submitting, onComplete, onSkip }: CandidatesViewProps) {
+  const [customSelected, setCustomSelected] = useState<Set<string> | null>(null)
+  const selected = customSelected ?? new Set(candidates.map((c) => c.url))
+
+  function toggleCandidate(url: string) {
+    const next = new Set(selected)
+    if (next.has(url)) { next.delete(url) } else { next.add(url) }
+    setCustomSelected(next)
   }
 
   return (
@@ -122,16 +131,10 @@ export function RecipeCandidates() {
         ))}
       </div>
       <div className="mt-6 space-y-2">
-        <Button
-          className="w-full"
-          onClick={() => handleComplete(candidates.filter((c) => selected.has(c.url)))}
-          disabled={submitting || selected.size === 0}
-        >
+        <Button className="w-full" onClick={() => onComplete(candidates.filter((c) => selected.has(c.url)))} disabled={submitting || selected.size === 0}>
           {submitting ? '登録中…' : `まとめて登録する（${selected.size}件）`}
         </Button>
-        <Button variant="ghost" className="w-full" onClick={() => handleComplete([])} disabled={submitting}>
-          スキップして始める
-        </Button>
+        <Button variant="ghost" className="w-full" onClick={onSkip} disabled={submitting}>スキップして始める</Button>
       </div>
     </div>
   )
@@ -142,8 +145,9 @@ function CandidateCard({ candidate, checked, onToggle }: { candidate: RecipeCand
     <div className="flex items-start gap-3 rounded-lg border p-3">
       <Checkbox id={candidate.url} checked={checked} onCheckedChange={onToggle} className="mt-1" />
       {candidate.imageUrl && (
-        <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded">
-          <Image src={candidate.imageUrl} alt={candidate.title} fill className="object-cover" unoptimized />
+        <div className="h-16 w-16 shrink-0 overflow-hidden rounded bg-muted">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={candidate.imageUrl} alt={candidate.title} className="h-full w-full object-cover" />
         </div>
       )}
       <label htmlFor={candidate.url} className="flex-1 cursor-pointer space-y-0.5">

--- a/src/components/providers/onboarding-guard.tsx
+++ b/src/components/providers/onboarding-guard.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useEffect, useState, type ReactNode } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
+import { useAuth } from '@/lib/auth'
+
+interface OnboardingGuardProps {
+  children: ReactNode
+}
+
+export function OnboardingGuard({ children }: OnboardingGuardProps) {
+  const { user, isLoading } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+  const [checked, setChecked] = useState(false)
+  const isOnboardingPath = pathname.startsWith('/onboarding')
+
+  useEffect(() => {
+    if (isLoading || !user || isOnboardingPath) return
+    const checkStatus = async () => {
+      try {
+        const res = await fetch(`/api/auth/onboarding-status?lineUserId=${user.lineUserId}`)
+        const data = await res.json() as { completed: boolean }
+        if (!data.completed) {
+          router.replace('/onboarding')
+        } else {
+          setChecked(true)
+        }
+      } catch {
+        setChecked(true)
+      }
+    }
+    checkStatus()
+  }, [user, isLoading, isOnboardingPath, router])
+
+  // オンボーディングページはガード不要
+  if (isOnboardingPath) return <>{children}</>
+  if (!checked) return null
+
+  return <>{children}</>
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/src/lib/db/queries/recipe-search.ts
+++ b/src/lib/db/queries/recipe-search.ts
@@ -1,0 +1,177 @@
+import { supabase } from '@/lib/db/client'
+import type { Tables } from '@/types/database'
+import type { SortOrder, RecipeWithIngredients, RecipeIngredient } from '@/types/recipe'
+import { getVectorSearchIds } from './recipe-embedding'
+
+const MIN_ILIKE_RESULTS = 3
+
+export interface FetchRecipesParams {
+  userId: string
+  searchQuery?: string
+  ingredientIds?: string[]
+  sortOrder?: SortOrder
+}
+
+type RecipeIngredientRow = {
+  recipe_id: string
+  ingredient_id: string
+  is_main: boolean
+  ingredients: { id: string; name: string } | null
+}
+
+type IngredientWithParent = {
+  id: string
+  parent_id: string | null
+}
+
+function buildIngredientMap(rows: RecipeIngredientRow[]): Map<string, RecipeIngredient[]> {
+  const map = new Map<string, RecipeIngredient[]>()
+  for (const ri of rows) {
+    if (!ri.ingredients) continue
+    const list = map.get(ri.recipe_id) || []
+    list.push({ id: ri.ingredients.id, name: ri.ingredients.name, isMain: ri.is_main })
+    map.set(ri.recipe_id, list)
+  }
+  return map
+}
+
+async function getIngredientAndChildIds(ingredientIds: string[]): Promise<Map<string, string[]>> {
+  if (ingredientIds.length === 0) return new Map()
+
+  const { data, error } = await supabase
+    .from('ingredients')
+    .select('id, parent_id')
+    .or(`id.in.(${ingredientIds.join(',')}),parent_id.in.(${ingredientIds.join(',')})`)
+
+  if (error) {
+    console.error('[getIngredientAndChildIds] Error:', error)
+    return new Map(ingredientIds.map((id) => [id, [id]]))
+  }
+
+  const rows = (data ?? []) as IngredientWithParent[]
+  const result = new Map<string, string[]>()
+  for (const searchId of ingredientIds) {
+    const matchingIds = rows
+      .filter((row) => row.id === searchId || row.parent_id === searchId)
+      .map((row) => row.id)
+    if (!matchingIds.includes(searchId)) matchingIds.push(searchId)
+    result.set(searchId, matchingIds)
+  }
+  return result
+}
+
+async function filterByIngredients(
+  recipes: RecipeWithIngredients[],
+  ingredientIds: string[]
+): Promise<RecipeWithIngredients[]> {
+  if (ingredientIds.length === 0) return recipes
+  const expandedIdsMap = await getIngredientAndChildIds(ingredientIds)
+  return recipes.filter((recipe) => {
+    const recipeIngredientIds = recipe.mainIngredients.map((i) => i.id)
+    return ingredientIds.every((searchId) => {
+      const expandedIds = expandedIdsMap.get(searchId) || [searchId]
+      return expandedIds.some((id) => recipeIngredientIds.includes(id))
+    })
+  })
+}
+
+type DbSortOrder = Exclude<SortOrder, 'fewest_ingredients'>
+
+const DB_SORT_OPTS: Record<DbSortOrder, [string, object]> = {
+  newest: ['created_at', { ascending: false }],
+  oldest: ['created_at', { ascending: true }],
+  most_viewed: ['view_count', { ascending: false }],
+  recently_viewed: ['last_viewed_at', { ascending: false, nullsFirst: false }],
+  shortest_cooking: ['cooking_time_minutes', { ascending: true, nullsFirst: false }],
+}
+
+function applySortOrder<T>(query: T, sortOrder: SortOrder): T {
+  const q = query as { order: (col: string, opts: object) => T }
+  const dbSortOrder: DbSortOrder = sortOrder === 'fewest_ingredients' ? 'newest' : sortOrder
+  const [col, opt] = DB_SORT_OPTS[dbSortOrder]
+  return q.order(col, opt)
+}
+
+function sortByIngredientCount(recipes: Tables<'recipes'>[]): Tables<'recipes'>[] {
+  return [...recipes].sort((a, b) => {
+    const aLen = Array.isArray(a.ingredients_raw) ? a.ingredients_raw.length : 999
+    const bLen = Array.isArray(b.ingredients_raw) ? b.ingredients_raw.length : 999
+    return aLen - bLen
+  })
+}
+
+async function fetchIngredientMap(recipeIds: string[]): Promise<Map<string, RecipeIngredient[]>> {
+  const { data, error } = await supabase
+    .from('recipe_ingredients')
+    .select('recipe_id, ingredient_id, is_main, ingredients(id, name)')
+    .in('recipe_id', recipeIds)
+    .eq('is_main', true)
+  if (error) throw error
+  return buildIngredientMap((data ?? []) as RecipeIngredientRow[])
+}
+
+async function searchRecipesHybrid(userId: string, searchQuery: string, sortOrder: SortOrder): Promise<Tables<'recipes'>[]> {
+  const term = `%${searchQuery}%`
+  let query = supabase.from('recipes').select('*').eq('user_id', userId)
+    .or(`title.ilike.${term},memo.ilike.${term},source_name.ilike.${term}`)
+  query = applySortOrder(query, sortOrder)
+  const { data, error } = await query
+  if (error) throw error
+  const ilikeRecipes = (data ?? []) as Tables<'recipes'>[]
+  if (ilikeRecipes.length >= MIN_ILIKE_RESULTS) return ilikeRecipes
+
+  try {
+    const additionalIds = await getVectorSearchIds(supabase, userId, searchQuery, ilikeRecipes.map((r) => r.id), 20)
+    if (additionalIds.length > 0) {
+      const { data: extra } = await supabase.from('recipes').select('*').in('id', additionalIds)
+      return [...ilikeRecipes, ...((extra ?? []) as Tables<'recipes'>[])]
+    }
+  } catch (e) { console.error('[searchRecipesHybrid] Vector search failed:', e) }
+  return ilikeRecipes
+}
+
+async function fetchRecipesFromDb(
+  userId: string,
+  searchQuery: string | undefined,
+  sortOrder: SortOrder
+): Promise<Tables<'recipes'>[]> {
+  let recipes: Tables<'recipes'>[]
+  if (!searchQuery?.trim()) {
+    let query = supabase.from('recipes').select('*').eq('user_id', userId)
+    query = applySortOrder(query, sortOrder)
+    const { data, error } = await query
+    if (error) throw error
+    recipes = (data ?? []) as Tables<'recipes'>[]
+  } else {
+    recipes = await searchRecipesHybrid(userId, searchQuery.trim(), sortOrder)
+  }
+  return sortOrder === 'fewest_ingredients' ? sortByIngredientCount(recipes) : recipes
+}
+
+/** ユーザーのレシピ一覧を取得 */
+export async function fetchRecipes(
+  params: FetchRecipesParams
+): Promise<{ data: RecipeWithIngredients[]; error: Error | null }> {
+  const { userId: lineUserId, searchQuery, ingredientIds = [], sortOrder = 'newest' } = params
+
+  try {
+    const { data: user } = await supabase
+      .from('users')
+      .select('id')
+      .eq('line_user_id', lineUserId)
+      .single()
+
+    if (!user) return { data: [], error: null }
+
+    const userId = (user as { id: string }).id
+    const recipes = await fetchRecipesFromDb(userId, searchQuery, sortOrder)
+    if (recipes.length === 0) return { data: [], error: null }
+
+    const ingredientMap = await fetchIngredientMap(recipes.map((r) => r.id))
+    const result = recipes.map((r) => ({ ...r, mainIngredients: ingredientMap.get(r.id) || [] }))
+
+    return { data: await filterByIngredients(result, ingredientIds), error: null }
+  } catch (err) {
+    return { data: [], error: err instanceof Error ? err : new Error('Unknown error') }
+  }
+}

--- a/src/lib/db/queries/recipes.ts
+++ b/src/lib/db/queries/recipes.ts
@@ -1,206 +1,17 @@
 import { SupabaseClient } from '@supabase/supabase-js'
-import { supabase, createServerClient } from '@/lib/db/client'
-import type { Database, Json, Tables, TablesInsert } from '@/types/database'
-import type { SortOrder, RecipeWithIngredients, RecipeIngredient, CreateRecipeInput } from '@/types/recipe'
-import { getVectorSearchIds } from './recipe-embedding'
-
-const MIN_ILIKE_RESULTS = 3
+import { createServerClient } from '@/lib/db/client'
+import type { Database, Json, TablesInsert } from '@/types/database'
+import type { CreateRecipeInput } from '@/types/recipe'
 
 type TypedSupabaseClient = SupabaseClient<Database>
 
-export interface FetchRecipesParams {
-  userId: string
-  searchQuery?: string
-  ingredientIds?: string[]
-  sortOrder?: SortOrder
-}
-
-type RecipeIngredientRow = {
-  recipe_id: string
-  ingredient_id: string
-  is_main: boolean
-  ingredients: { id: string; name: string } | null
-}
-
-/** レシピごとの食材マップを構築 */
-function buildIngredientMap(rows: RecipeIngredientRow[]): Map<string, RecipeIngredient[]> {
-  const map = new Map<string, RecipeIngredient[]>()
-  for (const ri of rows) {
-    if (!ri.ingredients) continue
-    const list = map.get(ri.recipe_id) || []
-    list.push({ id: ri.ingredients.id, name: ri.ingredients.name, isMain: ri.is_main })
-    map.set(ri.recipe_id, list)
-  }
-  return map
-}
-
-type IngredientWithParent = {
-  id: string
-  parent_id: string | null
-}
-
-/**
- * 食材IDとその子食材IDを取得（親子展開）
- * 例: 「豚肉」のIDを渡すと、「豚肉」「豚バラ肉」「豚こま切れ肉」等のIDを返す
- */
-async function getIngredientAndChildIds(ingredientIds: string[]): Promise<Map<string, string[]>> {
-  if (ingredientIds.length === 0) return new Map()
-
-  const { data, error } = await supabase
-    .from('ingredients')
-    .select('id, parent_id')
-    .or(`id.in.(${ingredientIds.join(',')}),parent_id.in.(${ingredientIds.join(',')})`)
-
-  if (error) {
-    console.error('[getIngredientAndChildIds] Error:', error)
-    return new Map(ingredientIds.map((id) => [id, [id]]))
-  }
-
-  const rows = (data ?? []) as IngredientWithParent[]
-
-  // 各検索食材IDに対して、マッチするID一覧を構築
-  const result = new Map<string, string[]>()
-  for (const searchId of ingredientIds) {
-    const matchingIds = rows
-      .filter((row) => row.id === searchId || row.parent_id === searchId)
-      .map((row) => row.id)
-    // 自分自身も含める
-    if (!matchingIds.includes(searchId)) {
-      matchingIds.push(searchId)
-    }
-    result.set(searchId, matchingIds)
-  }
-  return result
-}
-
-/** 食材IDでフィルタリング（AND ロジック + 親子展開） */
-async function filterByIngredients(
-  recipes: RecipeWithIngredients[],
-  ingredientIds: string[]
-): Promise<RecipeWithIngredients[]> {
-  if (ingredientIds.length === 0) return recipes
-
-  // 各検索食材について、その食材+子食材のIDを取得
-  const expandedIdsMap = await getIngredientAndChildIds(ingredientIds)
-
-  return recipes.filter((recipe) => {
-    const recipeIngredientIds = recipe.mainIngredients.map((i) => i.id)
-
-    // 全ての検索食材について、その食材か子食材がレシピに含まれているか
-    return ingredientIds.every((searchId) => {
-      const expandedIds = expandedIdsMap.get(searchId) || [searchId]
-      return expandedIds.some((id) => recipeIngredientIds.includes(id))
-    })
-  })
-}
-
-/** ユーザーのレシピ一覧を取得 */
-export async function fetchRecipes(
-  params: FetchRecipesParams
-): Promise<{ data: RecipeWithIngredients[]; error: Error | null }> {
-  const { userId: lineUserId, searchQuery, ingredientIds = [], sortOrder = 'newest' } = params
-
-  try {
-    const { data: user } = await supabase
-      .from('users')
-      .select('id')
-      .eq('line_user_id', lineUserId)
-      .single()
-
-    if (!user) return { data: [], error: null }
-
-    const userId = (user as { id: string }).id
-    const recipes = await fetchRecipesFromDb(userId, searchQuery, sortOrder)
-    if (recipes.length === 0) return { data: [], error: null }
-
-    const ingredientMap = await fetchIngredientMap(recipes.map((r) => r.id))
-    const result = recipes.map((r) => ({ ...r, mainIngredients: ingredientMap.get(r.id) || [] }))
-
-    return { data: await filterByIngredients(result, ingredientIds), error: null }
-  } catch (err) {
-    return { data: [], error: err instanceof Error ? err : new Error('Unknown error') }
-  }
-}
-
-async function fetchRecipesFromDb(
-  userId: string,
-  searchQuery: string | undefined,
-  sortOrder: SortOrder
-): Promise<Tables<'recipes'>[]> {
-  let recipes: Tables<'recipes'>[]
-
-  if (!searchQuery?.trim()) {
-    let query = supabase.from('recipes').select('*').eq('user_id', userId)
-    query = applySortOrder(query, sortOrder)
-    const { data, error } = await query
-    if (error) throw error
-    recipes = (data ?? []) as Tables<'recipes'>[]
-  } else {
-    recipes = await searchRecipesHybrid(userId, searchQuery.trim(), sortOrder)
-  }
-
-  return sortOrder === 'fewest_ingredients' ? sortByIngredientCount(recipes) : recipes
-}
-
-/** ハイブリッド検索: ILIKE優先、結果が少ない場合はベクトル検索で補完 */
-async function searchRecipesHybrid(userId: string, searchQuery: string, sortOrder: SortOrder): Promise<Tables<'recipes'>[]> {
-  const term = `%${searchQuery}%`
-  let query = supabase.from('recipes').select('*').eq('user_id', userId)
-    .or(`title.ilike.${term},memo.ilike.${term},source_name.ilike.${term}`)
-  query = applySortOrder(query, sortOrder)
-  const { data, error } = await query
-  if (error) throw error
-  const ilikeRecipes = (data ?? []) as Tables<'recipes'>[]
-  if (ilikeRecipes.length >= MIN_ILIKE_RESULTS) return ilikeRecipes
-
-  try {
-    const additionalIds = await getVectorSearchIds(supabase, userId, searchQuery, ilikeRecipes.map((r) => r.id), 20)
-    if (additionalIds.length > 0) {
-      const { data: extra } = await supabase.from('recipes').select('*').in('id', additionalIds)
-      return [...ilikeRecipes, ...((extra ?? []) as Tables<'recipes'>[])]
-    }
-  } catch (e) { console.error('[searchRecipesHybrid] Vector search failed:', e) }
-  return ilikeRecipes
-}
-
-type DbSortOrder = Exclude<SortOrder, 'fewest_ingredients'>
-
-const DB_SORT_OPTS: Record<DbSortOrder, [string, object]> = {
-  newest: ['created_at', { ascending: false }],
-  oldest: ['created_at', { ascending: true }],
-  most_viewed: ['view_count', { ascending: false }],
-  recently_viewed: ['last_viewed_at', { ascending: false, nullsFirst: false }],
-  shortest_cooking: ['cooking_time_minutes', { ascending: true, nullsFirst: false }],
-}
-
-function applySortOrder<T>(query: T, sortOrder: SortOrder): T {
-  const q = query as { order: (col: string, opts: object) => T }
-  const dbSortOrder: DbSortOrder = sortOrder === 'fewest_ingredients' ? 'newest' : sortOrder
-  const [col, opt] = DB_SORT_OPTS[dbSortOrder]
-  return q.order(col, opt)
-}
-
-function sortByIngredientCount(recipes: Tables<'recipes'>[]): Tables<'recipes'>[] {
-  return [...recipes].sort((a, b) => {
-    const aLen = Array.isArray(a.ingredients_raw) ? a.ingredients_raw.length : 999
-    const bLen = Array.isArray(b.ingredients_raw) ? b.ingredients_raw.length : 999
-    return aLen - bLen
-  })
-}
-
-async function fetchIngredientMap(recipeIds: string[]): Promise<Map<string, RecipeIngredient[]>> {
-  const { data, error } = await supabase
-    .from('recipe_ingredients')
-    .select('recipe_id, ingredient_id, is_main, ingredients(id, name)')
-    .in('recipe_id', recipeIds)
-    .eq('is_main', true)
-
-  if (error) throw error
-  return buildIngredientMap((data ?? []) as RecipeIngredientRow[])
-}
-
 export interface CreateRecipeResult {
   id: string
+}
+
+export interface CreateRecipeError {
+  message: string
+  code?: string
 }
 
 async function getUserIdByLineUserId(client: TypedSupabaseClient, lineUserId: string): Promise<string | null> {
@@ -217,7 +28,6 @@ async function insertRecipe(client: TypedSupabaseClient, userId: string, input: 
     image_url: input.imageUrl || null,
     memo: input.memo || null,
     ingredients_raw: (input.ingredientsRaw ?? []) as unknown as Json,
-    // 食材マッチングが完了している場合は true
     ingredients_linked: input.ingredientIds.length > 0,
     cooking_time_minutes: input.cookingTimeMinutes ?? null,
   }
@@ -237,11 +47,6 @@ async function insertRecipeIngredients(client: TypedSupabaseClient, recipeId: st
   if (error) console.error('[createRecipe] recipe_ingredients insert error:', error)
 }
 
-export interface CreateRecipeError {
-  message: string
-  code?: string
-}
-
 /** レシピを新規作成 */
 export async function createRecipe(input: CreateRecipeInput): Promise<{ data: CreateRecipeResult | null; error: CreateRecipeError | null }> {
   const client = createServerClient()
@@ -255,12 +60,9 @@ export async function createRecipe(input: CreateRecipeInput): Promise<{ data: Cr
 
     await insertRecipeIngredients(client, recipe.id, input.ingredientIds)
 
-    // 埋め込みは pg_cron + Edge Function でバッチ生成される（title_embedding = NULL で保存）
-
     return { data: { id: recipe.id }, error: null }
   } catch (err: unknown) {
     console.error('[createRecipe] Error:', err)
-    // PostgreSQLエラー（Supabaseから返される形式）を保持
     if (err && typeof err === 'object' && 'code' in err) {
       const pgError = err as { code: string; message?: string }
       return { data: null, error: { message: pgError.message || 'Database error', code: pgError.code } }
@@ -269,5 +71,8 @@ export async function createRecipe(input: CreateRecipeInput): Promise<{ data: Cr
   }
 }
 
-// 詳細関連のクエリは recipe-detail.ts から re-export
+// 検索・一覧取得は recipe-search.ts から re-export
+export { fetchRecipes } from './recipe-search'
+export type { FetchRecipesParams } from './recipe-search'
+// 詳細関連は recipe-detail.ts から re-export
 export { fetchRecipeById, deleteRecipe, updateRecipeMemo, recordRecipeView } from './recipe-detail'

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -234,24 +234,57 @@ export type Database = {
           },
         ]
       }
+      onboarding_sessions: {
+        Row: {
+          id: string
+          user_id: string
+          preferences: Json
+          candidates: Json | null
+          status: string
+          created_at: string | null
+          expires_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          preferences: Json
+          candidates?: Json | null
+          status?: string
+          created_at?: string | null
+          expires_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          preferences?: Json
+          candidates?: Json | null
+          status?: string
+          created_at?: string | null
+          expires_at?: string | null
+        }
+        Relationships: []
+      }
       users: {
         Row: {
           created_at: string | null
           display_name: string
           id: string
           line_user_id: string
+          onboarding_completed_at: string | null
         }
         Insert: {
           created_at?: string | null
           display_name: string
           id?: string
           line_user_id: string
+          onboarding_completed_at?: string | null
         }
         Update: {
           created_at?: string | null
           display_name?: string
           id?: string
           line_user_id?: string
+          onboarding_completed_at?: string | null
         }
         Relationships: []
       }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -372,6 +372,9 @@ verify_jwt = false
 [functions.auto-alias]
 verify_jwt = false
 
+[functions.onboarding-scrape]
+verify_jwt = false
+
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 

--- a/supabase/functions/onboarding-scrape/index.ts
+++ b/supabase/functions/onboarding-scrape/index.ts
@@ -1,0 +1,311 @@
+/**
+ * オンボーディング スクレイピング Edge Function
+ *
+ * POST body: { sessionId: string }
+ *
+ * 処理:
+ * 1. onboarding_sessions から preferences を取得
+ * 2. DELISH KITCHEN + Nadia を並列スクレイピング
+ * 3. フィルタリング（苦手食材・調理時間）
+ * 4. セッションに candidates を保存
+ * 5. LINE push 通知を送信
+ */
+
+import { createClient } from 'npm:@supabase/supabase-js@2'
+
+const TIMEOUT_MS = 15000
+const MAX_RESULTS_PER_SITE = 5
+
+const SITES = {
+  delishkitchen: {
+    searchUrl: (q: string) => `https://delishkitchen.tv/search?q=${encodeURIComponent(q)}`,
+    urlPattern: /https:\/\/delishkitchen\.tv\/recipes\/\d+/g,
+    urlPrefix: '',
+  },
+  nadia: {
+    searchUrl: (q: string) => `https://oceans-nadia.com/search?keyword=${encodeURIComponent(q)}`,
+    urlPattern: /\/user\/\d+\/recipe\/\d+/g,
+    urlPrefix: 'https://oceans-nadia.com',
+  },
+}
+
+interface Preferences {
+  searchQuery: string
+  dislikedIngredients: string[]
+  maxCookingMinutes: number | null
+}
+
+interface RecipeCandidate {
+  url: string
+  title: string
+  imageUrl: string
+  cookingTimeMinutes: number | null
+  ingredientsRaw: { name: string; amount: string }[]
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const controller = new AbortController()
+  const tid = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Language': 'ja,en;q=0.9',
+      },
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    return await res.text()
+  } finally {
+    clearTimeout(tid)
+  }
+}
+
+function extractUrlsFromHtml(html: string, pattern: RegExp, prefix: string): string[] {
+  const matches = html.match(pattern) ?? []
+  return [...new Set(matches)].map((u) => `${prefix}${u}`)
+}
+
+function parseIso8601Duration(v: unknown): number | null {
+  if (typeof v !== 'string') return null
+  const m = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(v)
+  if (!m) return null
+  const total = (parseInt(m[1] ?? '0') * 60) + parseInt(m[2] ?? '0') + Math.round(parseInt(m[3] ?? '0') / 60)
+  return total > 0 ? total : null
+}
+
+function extractImageUrl(image: unknown): string {
+  if (!image) return ''
+  if (typeof image === 'string') return image
+  if (Array.isArray(image)) {
+    const first = image[0]
+    if (typeof first === 'string') return first
+    if (first && typeof first === 'object' && 'url' in first) return String((first as Record<string, unknown>).url ?? '')
+    return ''
+  }
+  if (typeof image === 'object' && 'url' in image) return String((image as Record<string, unknown>).url ?? '')
+  return ''
+}
+
+function extractJsonLdRecipe(html: string, sourceUrl: string): RecipeCandidate | null {
+  const pattern = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
+  let match
+  while ((match = pattern.exec(html)) !== null) {
+    try {
+      const data = JSON.parse(match[1])
+      const recipe = findRecipeInJsonLd(data)
+      if (recipe) {
+        const cookTime = parseIso8601Duration(recipe.cookTime) ?? parseIso8601Duration(recipe.totalTime)
+        const ingredients: string[] = Array.isArray(recipe.recipeIngredient)
+          ? recipe.recipeIngredient.filter((i: unknown) => typeof i === 'string')
+          : []
+        return {
+          url: sourceUrl,
+          title: recipe.name,
+          imageUrl: extractImageUrl(recipe.image),
+          cookingTimeMinutes: cookTime ?? null,
+          ingredientsRaw: ingredients.map((name: string) => ({ name, amount: '' })),
+        }
+      }
+    } catch { /* skip */ }
+  }
+  return null
+}
+
+function findRecipeInJsonLd(data: unknown): Record<string, unknown> | null {
+  if (!data || typeof data !== 'object') return null
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      const r = findRecipeInJsonLd(item)
+      if (r) return r
+    }
+    return null
+  }
+  const obj = data as Record<string, unknown>
+  if (isRecipeType(obj['@type']) && typeof obj['name'] === 'string') return obj
+  if (Array.isArray(obj['@graph'])) {
+    for (const item of obj['@graph']) {
+      const r = findRecipeInJsonLd(item)
+      if (r) return r
+    }
+  }
+  return null
+}
+
+function isRecipeType(t: unknown): boolean {
+  if (t === 'Recipe') return true
+  if (Array.isArray(t) && t.includes('Recipe')) return true
+  return false
+}
+
+function extractNextDataRecipe(html: string, sourceUrl: string): RecipeCandidate | null {
+  const m = /<script id="__NEXT_DATA__" type="application\/json">([\s\S]*?)<\/script>/i.exec(html)
+  if (!m?.[1]) return null
+  try {
+    const data = JSON.parse(m[1]) as Record<string, unknown>
+    const props = data['props'] as Record<string, unknown> | undefined
+    const pageProps = props?.['pageProps'] as Record<string, unknown> | undefined
+    const recipe = (pageProps?.['data'] as Record<string, unknown> | undefined)?.['publishedRecipe'] as Record<string, unknown> | undefined
+    if (!recipe?.['title'] || typeof recipe['title'] !== 'string') return null
+
+    const ingredients = Array.isArray(recipe['ingredients'])
+      ? (recipe['ingredients'] as Array<Record<string, unknown>>)
+          .map((i) => ({ name: String(i['name'] ?? '').replace(/\s*[\(（].*?[\)）]\s*$/, '').trim(), amount: String(i['amount'] ?? '') }))
+          .filter((i) => i.name.length > 0)
+      : []
+
+    const imageSet = Array.isArray(recipe['imageSet']) ? recipe['imageSet'] as Array<Record<string, unknown>> : []
+    const rawPath = imageSet[0]?.['path']
+    const imagePath = typeof rawPath === 'string' ? rawPath : ''
+    const imageUrl = imagePath.startsWith('http') ? imagePath : `https://asset.oceans-nadia.com${imagePath}`
+
+    return {
+      url: sourceUrl,
+      title: recipe['title'],
+      imageUrl,
+      cookingTimeMinutes: typeof recipe['cookTime'] === 'number' ? recipe['cookTime'] : null,
+      ingredientsRaw: ingredients,
+    }
+  } catch { return null }
+}
+
+async function scrapeRecipeUrl(url: string): Promise<RecipeCandidate | null> {
+  try {
+    const html = await fetchHtml(url)
+    return extractJsonLdRecipe(html, url) ?? extractNextDataRecipe(html, url)
+  } catch { return null }
+}
+
+async function scrapeSite(siteKey: keyof typeof SITES, query: string): Promise<RecipeCandidate[]> {
+  const site = SITES[siteKey]
+  try {
+    const html = await fetchHtml(site.searchUrl(query))
+    const urls = extractUrlsFromHtml(html, site.urlPattern, site.urlPrefix).slice(0, MAX_RESULTS_PER_SITE)
+    const results = await Promise.all(urls.map(scrapeRecipeUrl))
+    return results.filter((r): r is RecipeCandidate => r !== null)
+  } catch (e) {
+    console.error(`[onboarding-scrape] ${siteKey} failed:`, e)
+    return []
+  }
+}
+
+function filterCandidates(candidates: RecipeCandidate[], prefs: Preferences): RecipeCandidate[] {
+  return candidates.filter((c) => {
+    if (prefs.maxCookingMinutes != null && c.cookingTimeMinutes != null) {
+      if (c.cookingTimeMinutes > prefs.maxCookingMinutes) return false
+    }
+    if (prefs.dislikedIngredients.length > 0) {
+      const ingredientNames = c.ingredientsRaw.map((i) => i.name.toLowerCase())
+      for (const disliked of prefs.dislikedIngredients) {
+        if (ingredientNames.some((n) => n.includes(disliked.toLowerCase()))) return false
+      }
+    }
+    return true
+  })
+}
+
+async function sendLineNotification(lineUserId: string, candidateCount: number, appUrl: string): Promise<void> {
+  const token = Deno.env.get('LINE_CHANNEL_ACCESS_TOKEN')
+  if (!token) {
+    console.warn('[onboarding-scrape] LINE_CHANNEL_ACCESS_TOKEN not set')
+    return
+  }
+
+  const resultUrl = `${appUrl}/onboarding/result`
+
+  const message = candidateCount > 0
+    ? {
+        type: 'flex',
+        altText: `${candidateCount}件のレシピが見つかりました！`,
+        contents: {
+          type: 'bubble',
+          body: {
+            type: 'box',
+            layout: 'vertical',
+            contents: [
+              { type: 'text', text: '🍳 レシピが見つかりました！', weight: 'bold', size: 'md' },
+              { type: 'text', text: `${candidateCount}件のレシピ候補があります。`, size: 'sm', color: '#666666', margin: 'md' },
+            ],
+          },
+          footer: {
+            type: 'box',
+            layout: 'vertical',
+            contents: [
+              {
+                type: 'button',
+                style: 'primary',
+                action: { type: 'uri', label: '確認する', uri: resultUrl },
+              },
+            ],
+          },
+        },
+      }
+    : { type: 'text', text: '申し訳ありません。レシピが見つかりませんでした。\n別のキーワードでお試しください。' }
+
+  await fetch('https://api.line.me/v2/bot/message/push', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ to: lineUserId, messages: [message] }),
+  })
+}
+
+async function scrapeAndNotify(sessionId: string): Promise<void> {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const appUrl = Deno.env.get('APP_URL') ?? 'https://localhost:3000'
+
+  const supabase = createClient(supabaseUrl, supabaseKey)
+
+  const { data: session, error: fetchError } = await supabase
+    .from('onboarding_sessions')
+    .select('user_id, preferences')
+    .eq('id', sessionId)
+    .single()
+
+  if (fetchError || !session) {
+    console.error('[onboarding-scrape] Session not found:', fetchError)
+    return
+  }
+
+  const prefs = session.preferences as unknown as Preferences
+
+  try {
+    const [delish, nadia] = await Promise.all([
+      scrapeSite('delishkitchen', prefs.searchQuery),
+      scrapeSite('nadia', prefs.searchQuery),
+    ])
+
+    const all = filterCandidates([...delish, ...nadia], prefs)
+
+    // deno-lint-ignore no-explicit-any
+    await supabase
+      .from('onboarding_sessions')
+      .update({ candidates: all as unknown as any, status: 'completed' })
+      .eq('id', sessionId)
+
+    await sendLineNotification(session.user_id, all.length, appUrl)
+  } catch (e) {
+    console.error('[onboarding-scrape] Failed:', e)
+    await supabase.from('onboarding_sessions').update({ status: 'failed' }).eq('id', sessionId)
+    await sendLineNotification(session.user_id, 0, appUrl)
+  }
+}
+
+Deno.serve(async (req) => {
+  const { sessionId } = await req.json() as { sessionId: string }
+
+  if (!sessionId) {
+    return new Response(JSON.stringify({ error: 'Missing sessionId' }), { status: 400 })
+  }
+
+  EdgeRuntime.waitUntil(scrapeAndNotify(sessionId))
+
+  return new Response(JSON.stringify({ status: 'processing' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+})

--- a/supabase/functions/onboarding-scrape/index.ts
+++ b/supabase/functions/onboarding-scrape/index.ts
@@ -280,6 +280,7 @@ async function scrapeAndNotify(sessionId: string): Promise<void> {
     ])
 
     const all = filterCandidates([...delish, ...nadia], prefs)
+    console.log(`[onboarding-scrape] Done: delish=${delish.length}, nadia=${nadia.length}, filtered=${all.length}`)
 
     // deno-lint-ignore no-explicit-any
     await supabase

--- a/supabase/migrations/20260311000000_add_onboarding.sql
+++ b/supabase/migrations/20260311000000_add_onboarding.sql
@@ -1,0 +1,16 @@
+-- users テーブルにオンボーディング完了フラグ追加
+ALTER TABLE users ADD COLUMN IF NOT EXISTS onboarding_completed_at timestamptz;
+
+-- 既存ユーザーは完了済み扱い（既存ユーザーには表示しない）
+UPDATE users SET onboarding_completed_at = now() WHERE onboarding_completed_at IS NULL;
+
+-- オンボーディングセッション一時保存テーブル
+CREATE TABLE IF NOT EXISTS onboarding_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id text NOT NULL,
+  preferences jsonb NOT NULL,   -- { searchQuery, dislikedIngredients, maxCookingMinutes }
+  candidates jsonb,             -- 収集結果（完了後に格納）
+  status text DEFAULT 'pending', -- pending / completed / failed
+  created_at timestamptz DEFAULT now(),
+  expires_at timestamptz DEFAULT now() + interval '24 hours'
+);


### PR DESCRIPTION
## Summary

- 新規ユーザーのコールドスタート問題を解消するため、初回アクセス時にフォームで好みをヒアリングしバックグラウンドでレシピを収集する機能を実装
- DB マイグレーション（`onboarding_sessions` テーブル、`users.onboarding_completed_at`）
- 食材サジェスト入力コンポーネント（shadcn Popover + Command、バッジを入力欄の下に配置）
- 好みフォーム画面（好きな食材・苦手な食材・調理時間）
- Supabase Edge Function によるバックグラウンドスクレイピング（DELISH KITCHEN + Nadia）
- レシピ候補選択 UI（サイト名・元ページリンク・一括登録）
- OnboardingGuard によるリダイレクト制御（未完了ユーザーを `/onboarding` へ）
- LINE ウェルカムメッセージ更新（オンボーディング誘導）

## 追加が必要な環境変数

本番デプロイ時に以下の Supabase secrets を設定してください：

```bash
supabase secrets set LINE_CHANNEL_ACCESS_TOKEN=<トークン>
supabase secrets set APP_URL=https://<本番ドメイン>
```

## 既知の課題

- Nadia のスクレイピング結果が不安定な可能性あり → タスク #7 で別途対応予定

## Test plan

- [ ] `supabase migration up` でローカル DB にマイグレーション適用済み
- [ ] `/onboarding` フォームで食材入力 → 「レシピを探してもらう」送信
- [ ] `supabase functions serve` のログで `[onboarding-scrape] Done: delish=N, nadia=N, filtered=N` を確認
- [ ] `/onboarding/result` でレシピ候補が表示され、元ページリンクが機能する
- [ ] 「まとめて登録する」でホームにレシピが表示される
- [ ] 2回目アクセスで `/onboarding` にリダイレクトされない

🤖 Generated with [Claude Code](https://claude.com/claude-code)