### PR TITLE
feat: E2E テスト基盤を整備（Playwright）

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,55 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase
+        run: supabase start
+
+      - name: Export Supabase keys
+        run: |
+          eval $(supabase status --output env)
+          echo "SUPABASE_SECRET_KEY=$SECRET_KEY" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$PUBLISHABLE_KEY" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Stop Supabase
+        if: always()
+        run: supabase stop

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/SESSION.md
+++ b/SESSION.md
@@ -1,12 +1,16 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-03-18 (Nadia → クラシル差し替え完了)
+2026-03-18 (ホーム header にオンボーディング起動ボタン追加)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **一般公開準備完了**
 
 ## 直近の完了タスク
+- [x] **ホーム header にオンボーディング起動ボタン追加**
+  - Sparkles アイコンボタンをヘッダー右側（ソート選択の左隣）に配置
+  - クリックで `/onboarding` へ遷移（OnboardingGuard はパスを通過）
+  - 動作確認・再実行の入口として利用可能
 - [x] **オンボーディング機能実装・マージ**（PR #17）
   - フォーム形式（食材サジェスト付き入力 + 調理時間 Select）
   - Supabase Edge Function バックグラウンドスクレイピング（DELISH KITCHEN + クラシル）
@@ -56,17 +60,18 @@
 
 ## コミット履歴（直近）
 ```
+267f6dc feat: ホーム header にオンボーディング起動ボタンを追加
+58161c7 Merge pull request #18 from mktu/feature/add-onboarding
+583e28c docs: update SESSION.md for session handoff
 bfa8df4 fix: オンボーディングスクレイピングの Nadia をクラシルに差し替え
 a7796d4 docs: update SESSION.md for session handoff
-48bf66c docs: オンボーディングフローをアーキテクチャドキュメントに追記
-c859933 docs: update SESSION.md for session handoff
-5f837d3 feat: オンボーディング UI 改善とスクレイプ動作確認ログ追加
 ```
 
 ## GitHubリポジトリ
 https://github.com/mktu/recipe-app
 
 ## 参照すべきファイル
+- `src/components/features/home/home-client.tsx` - ホームページ（オンボーディングボタン追加済み）
 - `supabase/functions/onboarding-scrape/index.ts` - バックグラウンドスクレイピング Edge Function（DELISH KITCHEN + クラシル）
 - `scripts/test-onboarding-scrape.ts` - スクレイピング動作確認スクリプト
 - `src/components/features/onboarding/` - オンボーディング UI コンポーネント

--- a/docs/backlogs/README.md
+++ b/docs/backlogs/README.md
@@ -11,6 +11,7 @@
 | LINEチャットのレシピリスト改善 | [line-recipe-list.md](./line-recipe-list.md) | ✅ 完了 |
 | LINE カテゴリカードから LIFF 絞り込みページへの誘導 | [liff-category-filter.md](./liff-category-filter.md) | ✅ 完了 |
 | オンボーディングチャット - 初回レシピ一括登録 | [onboarding-chat.md](./onboarding-chat.md) | 📋 未着手 |
+| E2E テスト整備 | [e2e-testing.md](./e2e-testing.md) | 📋 未着手 |
 
 ## ステータス凡例
 

--- a/docs/backlogs/e2e-testing.md
+++ b/docs/backlogs/e2e-testing.md
@@ -1,0 +1,245 @@
+# E2E テスト整備
+
+## ステータス
+📋 未着手
+
+## 背景・課題
+
+- 機能追加が続いており、手動での動作確認コストが増大している
+- オンボーディング・レシピ追加・検索フィルターなど複数フローをまたぐ
+  デグレを検知する手段がない
+- 本番リリース前の品質保証を自動化したい
+
+## 方針
+
+### フレームワーク
+
+**Playwright** を採用。
+
+- Next.js App Router との相性が良い
+- ネットワークインターセプト（`page.route()`）で外部依存をモック可能
+- `@playwright/test` の組み込み機能が充実
+
+### DB 戦略
+
+**Local Supabase を使う**（モックなし）。
+
+ほぼ全フローが DB データを前提とするため、API を全モックすると
+「UI が静的なデータを表示できること」しか保証できず E2E の価値が低くなる。
+
+- ローカル: `supabase start` で起動
+- CI (GitHub Actions): `supabase/setup-cli` action + `supabase start`（ubuntu-latest は Docker 対応）
+- 各テストファイル実行前にテスト用ユーザーのデータをリセット（`supabase db reset` は重いため行単位で DELETE）
+
+### 認証
+
+**DevAuth モード**（`NEXT_PUBLIC_LIFF_ID=''`）を使用。LINE LIFF は不要。
+
+### 外部サービスのモック
+
+Playwright の `page.route()` でインターセプト：
+
+| サービス | モック理由 |
+|----------|-----------|
+| Edge Function（get-recipes, onboarding-scrape） | 実通信は遅い・不安定 |
+| Gemini AI（レシピ parse） | API コスト・再現性 |
+| Jina Reader API | 外部依存 |
+| LINE push 通知 | テスト環境から送信不可 |
+
+### ディレクトリ構造
+
+```
+e2e/
+├── fixtures/
+│   ├── auth.ts              # DevAuth ユーザー定数
+│   ├── db.ts                # テスト用 DB ヘルパー（シード・クリーン）
+│   └── mock-data.ts         # API モック用レスポンスデータ
+├── pages/                   # Page Object Model
+│   ├── home-page.ts
+│   ├── onboarding-page.ts
+│   ├── onboarding-result-page.ts
+│   ├── recipe-add-page.ts
+│   └── recipe-detail-page.ts
+├── onboarding.spec.ts
+├── home.spec.ts
+├── recipe-add.spec.ts
+├── recipe-detail.spec.ts
+└── playwright.config.ts
+```
+
+## テストシナリオ一覧
+
+### 優先度：高
+
+#### 1. OnboardingGuard の制御
+
+| ケース | 概要 |
+|--------|------|
+| 新規ユーザーリダイレクト | `onboarding_completed_at = NULL` の状態で `/` アクセス → `/onboarding` にリダイレクトされること |
+| 完了済みユーザー通過 | `onboarding_completed_at` が設定済みの状態で `/` アクセス → リダイレクトしないこと |
+| `/onboarding` は通過 | 未完了ユーザーが `/onboarding` にアクセスしても無限リダイレクトしないこと |
+
+#### 2. オンボーディング フルフロー
+
+| ケース | 概要 |
+|--------|------|
+| フルフロー | 食材入力 → 調理時間選択 → 送信 → ローディング → 候補表示 → 選択 → 登録 → ホームへ遷移 |
+| スキップ（フォーム） | フォームでスキップ → `onboarding_completed_at` がセットされホームへ遷移 |
+| スキップ（結果画面） | 候補表示後にスキップ → ホームへ遷移 |
+| スクレイピング失敗 | Edge Function が `failed` を返す → 失敗メッセージが表示されること |
+| 再実行 | 完了済みユーザーがホームのボタンから `/onboarding` に再アクセスできること |
+
+#### 3. レシピ追加フロー
+
+| ケース | 概要 |
+|--------|------|
+| フルフロー | URL 入力 → 確認画面（パース結果表示）→ 食材選択 → 保存 → ホームの一覧に反映 |
+| バリデーション | 不正な URL → エラー表示 |
+| 重複 URL | 登録済み URL → エラーまたは適切なメッセージ |
+
+### 優先度：中
+
+#### 4. ホーム画面
+
+| ケース | 概要 |
+|--------|------|
+| レシピ一覧表示 | 登録済みレシピが表示されること |
+| テキスト検索 | キーワード入力 → 一致するレシピのみ表示 |
+| 食材フィルター | 食材選択 → 対象レシピのみ表示 |
+| フィルタークリア | クリアボタン → 全件表示に戻ること |
+| ソート切り替え | 各ソート順に切り替えて一覧が並び替わること（最低 2〜3 種） |
+
+#### 5. レシピ詳細
+
+| ケース | 概要 |
+|--------|------|
+| 詳細表示 | レシピカードクリック → 詳細ページに遷移、タイトル・食材が表示されること |
+| メモ編集 | メモを入力・保存 → DB に反映・再表示で保持されること |
+| 削除 | 削除ボタン → 確認後削除 → ホームの一覧から消えること |
+
+### 優先度：低（後回し可）
+
+- 各ソート順の網羅的な確認
+- LP ページの表示確認
+- エラーページ（認証失敗・404 など）
+
+## テストデータ戦略
+
+### テスト用ユーザー
+
+```typescript
+// e2e/fixtures/auth.ts
+export const TEST_USER = {
+  lineUserId: 'e2e-test-user-001',
+  displayName: 'E2Eテストユーザー',
+}
+```
+
+DevAuth モードでは `dev-user-001` が使われるため、テスト用に別ユーザーを定義。
+（または `dev-user-001` をそのまま使い、テスト前後でデータをリセット）
+
+### シードデータ
+
+```typescript
+// e2e/fixtures/db.ts
+// テスト開始前: ユーザー・レシピ・食材リンクをシード
+// テスト終了後: テストユーザーのデータを DELETE
+```
+
+### Edge Function のモックレスポンス例
+
+```typescript
+// e2e/fixtures/mock-data.ts
+export const MOCK_ONBOARDING_CANDIDATES = [
+  {
+    url: 'https://delishkitchen.tv/recipes/123',
+    title: '鶏の唐揚げ',
+    imageUrl: 'https://example.com/image.jpg',
+    cookingTimeMinutes: 20,
+    ingredientsRaw: [
+      { name: '鶏もも肉', amount: '300g' },
+      { name: '醤油', amount: '大さじ2' },
+    ],
+    siteName: 'DELISH KITCHEN',
+  },
+]
+```
+
+## CI 設定
+
+### トリガー方針
+
+- **main マージ後（push to main）** に自動実行 → デグレを自動検知
+- **手動トリガー（workflow_dispatch）** → 本番デプロイ前など任意のタイミングで実行可能
+- PR 時は従来通り lint + build のみ（E2E は実行しない）
+
+将来的にテストが安定・拡充したら、PR 時にパスフィルターで限定実行する選択肢もある：
+
+```yaml
+# 将来の拡張例（UI/ロジック変更のある PR のみ）
+on:
+  pull_request:
+    paths:
+      - 'src/app/**'
+      - 'src/components/**'
+      - 'src/lib/**'
+```
+
+### ワークフロー設定
+
+```yaml
+# .github/workflows/e2e.yml（イメージ）
+name: E2E Tests
+on:
+  push:
+    branches: [main]   # main マージ後に自動実行
+  workflow_dispatch:   # 手動実行も可能
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+      - run: supabase start
+      - run: supabase db reset   # migrations + seed
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npx playwright test
+        env:
+          NEXT_PUBLIC_LIFF_ID: ''        # DevAuth モード
+          NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ env.LOCAL_ANON_KEY }}
+```
+
+既存の CI（lint + build）とは別 job として独立させる。
+
+## 実装順序
+
+1. **Playwright セットアップ**
+   - `npm install -D @playwright/test`
+   - `playwright.config.ts` 作成（baseURL, devServer 設定）
+   - GitHub Actions workflow 作成
+
+2. **共通フィクスチャ整備**
+   - `e2e/fixtures/db.ts`（シード・クリーン ヘルパー）
+   - `e2e/fixtures/mock-data.ts`（モックレスポンス定数）
+   - `e2e/fixtures/auth.ts`（テストユーザー定数）
+
+3. **OnboardingGuard テスト**（最小構成で動作確認）
+
+4. **オンボーディング フルフロー テスト**
+
+5. **レシピ追加テスト**
+
+6. **ホーム画面テスト**
+
+7. **レシピ詳細テスト**
+
+## 技術的な注意点
+
+- **DevAuth モード:** `.env.test` に `NEXT_PUBLIC_LIFF_ID=''` を設定
+- **ポーリングのテスト:** `page.route()` で `/api/onboarding/result` の最初の呼び出しは `pending`、2 回目以降は `completed` を返すように切り替える
+- **非同期待機:** `page.waitForURL()` / `page.waitForSelector()` を使い、固定 sleep は避ける
+- **Local Supabase の URL:** `supabase start` 後に `http://localhost:54321` で使用可能
+- **Edge Function（get-recipes）:** レシピ一覧 API を `page.route('/api/recipes/list', ...)` でインターセプトするか、Local Supabase 上で Edge Function を実際に起動するかは実装時に判断

--- a/e2e/fixtures/db.ts
+++ b/e2e/fixtures/db.ts
@@ -1,0 +1,75 @@
+import { createClient } from '@supabase/supabase-js'
+
+const SUPABASE_URL = 'http://localhost:54321'
+// SUPABASE_SECRET_KEY は playwright.config.ts が .env.local から読み込んでセット済み
+// CI では workflow が supabase status から取得して環境変数に渡す
+const SECRET_KEY = process.env.SUPABASE_SECRET_KEY
+if (!SECRET_KEY) throw new Error('SUPABASE_SECRET_KEY が未設定です。playwright.config.ts が .env.local を読み込めているか確認してください。')
+
+// DevAuth モードで使われるユーザー（src/lib/auth/constants.ts の DEV_USER と一致）
+export const E2E_LINE_USER_ID = 'dev-user-001'
+
+const admin = createClient(SUPABASE_URL, SECRET_KEY)
+
+/**
+ * テストユーザーを DB にセットアップする。
+ * 既存データを削除してから INSERT することで、onboarding_completed_at を確実に制御する。
+ */
+export async function setupUser({ onboardingCompleted }: { onboardingCompleted: boolean }) {
+  await cleanUserData()
+
+  const { error } = await admin
+    .from('users')
+    .insert({
+      line_user_id: E2E_LINE_USER_ID,
+      display_name: '開発ユーザー',
+      onboarding_completed_at: onboardingCompleted ? new Date().toISOString() : null,
+    })
+
+  if (error) throw new Error(`setupUser failed: ${error.message}`)
+}
+
+/**
+ * テストユーザーのデータを全て削除する（テスト後のクリーンアップ）。
+ */
+export async function cleanUserData() {
+  const { data: user } = await admin
+    .from('users')
+    .select('id')
+    .eq('line_user_id', E2E_LINE_USER_ID)
+    .maybeSingle()
+
+  if (!user) return
+
+  await Promise.all([
+    admin.from('recipes').delete().eq('user_id', user.id),
+    admin.from('onboarding_sessions').delete().eq('user_id', E2E_LINE_USER_ID),
+  ])
+
+  await admin.from('users').delete().eq('line_user_id', E2E_LINE_USER_ID)
+}
+
+/**
+ * テスト用レシピをシードする。ホーム画面・詳細テストで使用。
+ */
+export async function seedRecipes(count = 3) {
+  const { data: user } = await admin
+    .from('users')
+    .select('id')
+    .eq('line_user_id', E2E_LINE_USER_ID)
+    .single()
+
+  if (!user) throw new Error('User not found. Call setupUser() first.')
+
+  const recipes = Array.from({ length: count }, (_, i) => ({
+    user_id: user.id,
+    url: `https://delishkitchen.tv/recipes/e2e-test-${i + 1}`,
+    title: `テストレシピ ${i + 1}`,
+    source_name: 'DELISH KITCHEN',
+    cooking_time_minutes: (i + 1) * 10,
+    ingredients_raw: [{ name: '鶏肉', amount: '200g' }],
+  }))
+
+  const { data } = await admin.from('recipes').insert(recipes).select()
+  return data ?? []
+}

--- a/e2e/fixtures/mock-data.ts
+++ b/e2e/fixtures/mock-data.ts
@@ -1,0 +1,74 @@
+/**
+ * E2E テスト用のモックレスポンスデータ。
+ * page.route() でインターセプトする際に使用する。
+ */
+
+/** オンボーディング候補レシピ（Edge Function のスクレイピング結果を模倣） */
+export const MOCK_ONBOARDING_CANDIDATES = [
+  {
+    url: 'https://delishkitchen.tv/recipes/e2e-candidate-1',
+    title: '鶏の唐揚げ',
+    imageUrl: 'https://example.com/karaage.jpg',
+    cookingTimeMinutes: 20,
+    siteName: 'DELISH KITCHEN',
+    ingredientsRaw: [
+      { name: '鶏もも肉', amount: '300g' },
+      { name: '醤油', amount: '大さじ2' },
+      { name: '生姜', amount: '1片' },
+    ],
+  },
+  {
+    url: 'https://www.kurashiru.com/recipes/e2e-candidate-2',
+    title: '豚肉の生姜焼き',
+    imageUrl: 'https://example.com/shogayaki.jpg',
+    cookingTimeMinutes: 15,
+    siteName: 'クラシル',
+    ingredientsRaw: [
+      { name: '豚ロース肉', amount: '200g' },
+      { name: '生姜', amount: '1片' },
+    ],
+  },
+]
+
+/** /api/onboarding/result のレスポンス（pending 状態） */
+export const MOCK_ONBOARDING_RESULT_PENDING = {
+  session: {
+    id: 'e2e-session-001',
+    status: 'pending',
+    candidates: null,
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  },
+}
+
+/** /api/onboarding/result のレスポンス（completed 状態） */
+export const MOCK_ONBOARDING_RESULT_COMPLETED = {
+  session: {
+    id: 'e2e-session-001',
+    status: 'completed',
+    candidates: MOCK_ONBOARDING_CANDIDATES,
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  },
+}
+
+/** /api/onboarding/result のレスポンス（failed 状態） */
+export const MOCK_ONBOARDING_RESULT_FAILED = {
+  session: {
+    id: 'e2e-session-001',
+    status: 'failed',
+    candidates: null,
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  },
+}
+
+/** /api/recipes/parse のレスポンス（URL からのレシピ解析結果） */
+export const MOCK_RECIPE_PARSE_RESULT = {
+  title: 'テスト鶏の唐揚げ',
+  sourceName: 'DELISH KITCHEN',
+  imageUrl: 'https://example.com/karaage.jpg',
+  cookingTimeMinutes: 20,
+  ingredientIds: [],
+  ingredientsRaw: [
+    { name: '鶏もも肉', amount: '300g' },
+    { name: '醤油', amount: '大さじ2' },
+  ],
+}

--- a/e2e/onboarding-guard.spec.ts
+++ b/e2e/onboarding-guard.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+import { setupUser, cleanUserData, seedRecipes } from './fixtures/db'
+
+test.describe('OnboardingGuard', () => {
+  test.afterEach(async () => {
+    await cleanUserData()
+  })
+
+  test('新規ユーザーが / にアクセスすると /onboarding にリダイレクトされる', async ({ page }) => {
+    await setupUser({ onboardingCompleted: false })
+
+    await page.goto('/')
+    await page.waitForURL('**/onboarding')
+
+    expect(page.url()).toContain('/onboarding')
+  })
+
+  test('オンボーディング完了済みユーザーは / にアクセスしてもリダイレクトされない', async ({ page }) => {
+    await setupUser({ onboardingCompleted: true })
+    await seedRecipes()
+
+    await page.goto('/')
+    // OnboardingGuard が /api/auth/onboarding-status を呼んで完了を確認するまで待機
+    await page.waitForLoadState('networkidle')
+
+    await expect(page).toHaveURL('/')
+  })
+
+  test('/onboarding は未完了ユーザーでもリダイレクトせず表示される', async ({ page }) => {
+    await setupUser({ onboardingCompleted: false })
+
+    await page.goto('/onboarding')
+    await page.waitForLoadState('networkidle')
+
+    // /onboarding にいるままであること（無限リダイレクトにならない）
+    await expect(page).toHaveURL('/onboarding')
+  })
+})

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test'
+import { setupUser, cleanUserData } from './fixtures/db'
+import { MOCK_ONBOARDING_RESULT_PENDING, MOCK_ONBOARDING_RESULT_COMPLETED } from './fixtures/mock-data'
+
+test.describe('オンボーディング フロー', () => {
+  test.afterEach(async () => {
+    await cleanUserData()
+  })
+
+  test('フルフロー: 食材入力 → 送信 → 候補選択 → 登録 → ホームへ', async ({ page }) => {
+    await setupUser({ onboardingCompleted: false })
+
+    // Edge Function スクレイピングをモック（実通信しない）
+    await page.route('/api/onboarding/start', (route) =>
+      route.fulfill({ json: { sessionId: 'e2e-session-001' } })
+    )
+    // ポーリング: 1回目は pending、2回目以降は completed を返す
+    let pollCount = 0
+    await page.route('/api/onboarding/result**', (route) => {
+      pollCount++
+      route.fulfill({
+        json: pollCount === 1 ? MOCK_ONBOARDING_RESULT_PENDING : MOCK_ONBOARDING_RESULT_COMPLETED,
+      })
+    })
+
+    // /onboarding にアクセス → フォームが表示される
+    await page.goto('/onboarding')
+    await expect(page.getByRole('heading', { name: '好みを教えてください' })).toBeVisible()
+
+    // 食材を入力してサジェストから選択
+    const keywordInput = page.getByPlaceholder('例: 鶏肉、パスタ、時短…')
+    await keywordInput.click()
+    await keywordInput.fill('鶏')
+    await expect(page.getByRole('option').first()).toBeVisible()
+    await keywordInput.press('Enter')
+
+    // フォーム送信
+    await page.getByRole('button', { name: 'レシピを探してもらう' }).click()
+
+    // SubmittedView が表示される
+    await expect(page.getByText('バックグラウンドで探しています')).toBeVisible()
+
+    // 結果ページへ遷移
+    await page.getByRole('button', { name: '結果を確認する' }).click()
+    await page.waitForURL('**/onboarding/result')
+
+    // pending → completed になりレシピ候補が表示される
+    await expect(page.getByText('登録するレシピを選んでください')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('鶏の唐揚げ')).toBeVisible()
+
+    // まとめて登録（complete API は実 DB に当てる）
+    await page.getByRole('button', { name: /まとめて登録する/ }).click()
+
+    // ホームにリダイレクト
+    await page.waitForURL('/')
+    await expect(page).toHaveURL('/')
+  })
+
+  test('スキップ: 入力せずスキップ → ホームへ', async ({ page }) => {
+    await setupUser({ onboardingCompleted: false })
+
+    await page.goto('/onboarding')
+    await page.getByRole('button', { name: 'スキップして始める' }).click()
+
+    await page.waitForURL('/')
+    await expect(page).toHaveURL('/')
+  })
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,7 @@ const eslintConfig = defineConfig([
     rules: {
       "max-lines": "off",
       "max-lines-per-function": "off",
+      "complexity": "off",
     },
   },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,10 +33,12 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "dotenv": "^17.3.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
         "husky": "^9.1.7",
@@ -2621,6 +2623,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6673,6 +6691,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -9568,6 +9599,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "functions:build": "tsx scripts/build-edge-functions.ts",
     "functions:serve": "supabase functions serve --env-file .env.local",
     "functions:invoke": "curl -X POST http://localhost:54321/functions/v1/generate-embeddings -H 'Content-Type: application/json' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0'",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -52,10 +54,12 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.3.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "husky": "^9.1.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from '@playwright/test'
+import { config } from 'dotenv'
+
+// .env.local を読み込んでプロセス環境変数にセット（test worker に継承される）
+// ファイルが存在しない場合（CI 環境など）は静かにスキップ
+// override: false で CI の環境変数（$GITHUB_ENV 経由）を上書きしない
+config({ path: '.env.local', override: false, quiet: true })
+
+export default defineConfig({
+  testDir: './e2e',
+
+  // DB 状態を共有するため並列実行は無効
+  fullyParallel: false,
+  workers: 1,
+
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'html',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      // DevAuth モード（LIFF を使わない）
+      NEXT_PUBLIC_LIFF_ID: '',
+      NEXT_PUBLIC_SUPABASE_URL: 'http://localhost:54321',
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? '',
+      SUPABASE_SECRET_KEY: process.env.SUPABASE_SECRET_KEY ?? '',
+      // 外部サービスはテスト内で page.route() によりモック
+      GOOGLE_GENERATIVE_AI_API_KEY: process.env.GOOGLE_GENERATIVE_AI_API_KEY ?? 'dummy-for-e2e',
+      LINE_CHANNEL_SECRET: 'dummy-for-e2e',
+      LINE_CHANNEL_ACCESS_TOKEN: 'dummy-for-e2e',
+    },
+  },
+})

--- a/src/components/features/home/home-client.tsx
+++ b/src/components/features/home/home-client.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from 'react'
 import { useRouter } from 'next/navigation'
+import { Sparkles } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
 import { useRecipes } from '@/hooks/use-recipes'
 import { useRecipeFilters, InitialFilters } from '@/hooks/use-recipe-filters'
@@ -26,11 +27,12 @@ function useRecipeHandlers() {
     router.push(`/recipes/${id}`)
   }, [router])
   const handleAddRecipe = useCallback(() => router.push('/recipes/add'), [router])
-  return { handleRecipeClick, handleAddRecipe }
+  const handleOnboarding = useCallback(() => router.push('/onboarding'), [router])
+  return { handleRecipeClick, handleAddRecipe, handleOnboarding }
 }
 
 export function HomeClient({ ingredientCategories, initialFilters }: HomeClientProps) {
-  const { handleRecipeClick, handleAddRecipe } = useRecipeHandlers()
+  const { handleRecipeClick, handleAddRecipe, handleOnboarding } = useRecipeHandlers()
   const { isLoading: authLoading, isAuthenticated, error: authError, relogin } = useAuth()
   const filters = useRecipeFilters(ingredientCategories, initialFilters)
 
@@ -54,7 +56,7 @@ export function HomeClient({ ingredientCategories, initialFilters }: HomeClientP
 
   return (
     <div className="min-h-screen bg-background pb-24">
-      <Header sortOrder={filters.sortOrder} onSortChange={filters.setSortOrder} />
+      <Header sortOrder={filters.sortOrder} onSortChange={filters.setSortOrder} onOnboarding={handleOnboarding} />
       <main className="container mx-auto max-w-2xl space-y-4 p-4">
         <SearchBar value={filters.searchQuery} onChange={filters.setSearchQuery} />
         <div className="flex flex-wrap items-center gap-2">
@@ -109,14 +111,24 @@ function AuthErrorMessage({ error, onRelogin }: { error: string; onRelogin: () =
 interface HeaderProps {
   sortOrder: SortOrder
   onSortChange: (order: SortOrder) => void
+  onOnboarding: () => void
 }
 
-function Header({ sortOrder, onSortChange }: HeaderProps) {
+function Header({ sortOrder, onSortChange, onOnboarding }: HeaderProps) {
   return (
     <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur">
       <div className="container mx-auto flex max-w-2xl items-center justify-between p-4">
         <h1 className="text-xl font-bold text-primary">RecipeHub</h1>
-        <SortSelect value={sortOrder} onChange={onSortChange} />
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onOnboarding}
+            title="レシピを探してもらう"
+            className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          >
+            <Sparkles className="h-4 w-4" />
+          </button>
+          <SortSelect value={sortOrder} onChange={onSortChange} />
+        </div>
       </div>
     </header>
   )

--- a/src/components/features/onboarding/ingredient-suggest-input.tsx
+++ b/src/components/features/onboarding/ingredient-suggest-input.tsx
@@ -40,12 +40,11 @@ function useSuggestIngredients(query: string, selected: string[]) {
   }, [query, allIngredients, selected])
 }
 
-export function IngredientSuggestInput({ value, onChange, placeholder }: IngredientSuggestInputProps) {
+function useIngredientSuggestInput(value: string[], onChange: (value: string[]) => void) {
   const [query, setQuery] = useState('')
   const [open, setOpen] = useState(false)
   const [isComposing, setIsComposing] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(0)
-  const inputRef = useRef<HTMLInputElement>(null)
   const suggestions = useSuggestIngredients(query, value)
   const activeIndex = Math.min(highlightedIndex, suggestions.length - 1)
   const showDropdown = open && suggestions.length > 0
@@ -80,6 +79,40 @@ export function IngredientSuggestInput({ value, onChange, placeholder }: Ingredi
       setOpen(false)
     }
   }
+
+  return {
+    query, open, setOpen, isComposing, setIsComposing,
+    activeIndex, suggestions, showDropdown, setHighlightedIndex,
+    addFromSuggestion, handleQueryChange, handleKeyDown,
+  }
+}
+
+function IngredientBadgeList({ value, onChange }: { value: string[]; onChange: (v: string[]) => void }) {
+  if (value.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-1">
+      {value.map((name) => (
+        <Badge key={name} variant="secondary" className="gap-1 py-0.5">
+          {name}
+          <button
+            type="button"
+            onClick={() => onChange(value.filter((v) => v !== name))}
+            className="ml-0.5 rounded-full hover:bg-muted"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+export function IngredientSuggestInput({ value, onChange, placeholder }: IngredientSuggestInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const {
+    query, setOpen, setIsComposing, activeIndex, suggestions,
+    showDropdown, setHighlightedIndex, addFromSuggestion, handleQueryChange, handleKeyDown,
+  } = useIngredientSuggestInput(value, onChange)
 
   return (
     <div className="space-y-1.5">
@@ -121,22 +154,7 @@ export function IngredientSuggestInput({ value, onChange, placeholder }: Ingredi
           </Command>
         </PopoverContent>
       </Popover>
-      {value.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {value.map((name) => (
-            <Badge key={name} variant="secondary" className="gap-1 py-0.5">
-              {name}
-              <button
-                type="button"
-                onClick={() => onChange(value.filter((v) => v !== name))}
-                className="ml-0.5 rounded-full hover:bg-muted"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </Badge>
-          ))}
-        </div>
-      )}
+      <IngredientBadgeList value={value} onChange={onChange} />
     </div>
   )
 }

--- a/src/components/features/onboarding/preferences-form.tsx
+++ b/src/components/features/onboarding/preferences-form.tsx
@@ -14,7 +14,7 @@ interface FormState {
   maxCookingMinutes: string
 }
 
-export function PreferencesForm() {
+function usePreferencesForm() {
   const { user } = useAuth()
   const router = useRouter()
   const [form, setForm] = useState<FormState>({
@@ -29,10 +29,8 @@ export function PreferencesForm() {
     e.preventDefault()
     if (!user || form.searchKeywords.length === 0) return
     setSubmitting(true)
-
     const maxCookingMinutes = form.maxCookingMinutes === 'none' ? null : parseInt(form.maxCookingMinutes, 10)
     const searchQuery = form.searchKeywords.join(' ')
-
     try {
       const res = await fetch('/api/onboarding/start', {
         method: 'POST',
@@ -59,23 +57,75 @@ export function PreferencesForm() {
     router.replace('/')
   }
 
-  if (submitted) {
-    return (
-      <div className="flex min-h-screen flex-col items-center justify-center p-6 text-center">
-        <div className="max-w-sm space-y-4">
-          <p className="text-2xl">🍳</p>
-          <h2 className="text-lg font-semibold">バックグラウンドで探しています</h2>
-          <p className="text-sm text-muted-foreground">
-            完了したら LINE でお知らせします！<br />
-            見つかったら候補から登録してください。
-          </p>
-          <Button variant="outline" size="sm" onClick={() => router.replace('/onboarding/result')}>
-            結果を確認する
-          </Button>
-        </div>
+  return { form, setForm, submitting, submitted, handleSubmit, handleSkip }
+}
+
+function SubmittedView() {
+  const router = useRouter()
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-6 text-center">
+      <div className="max-w-sm space-y-4">
+        <p className="text-2xl">🍳</p>
+        <h2 className="text-lg font-semibold">バックグラウンドで探しています</h2>
+        <p className="text-sm text-muted-foreground">
+          完了したら LINE でお知らせします！<br />
+          見つかったら候補から登録してください。
+        </p>
+        <Button variant="outline" size="sm" onClick={() => router.replace('/onboarding/result')}>
+          結果を確認する
+        </Button>
       </div>
-    )
-  }
+    </div>
+  )
+}
+
+function PreferencesFormBody({ form, setForm, submitting, onSubmit }: {
+  form: FormState
+  setForm: React.Dispatch<React.SetStateAction<FormState>>
+  submitting: boolean
+  onSubmit: (e: React.FormEvent) => void
+}) {
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <div className="space-y-2">
+        <Label>好きな食材・料理名 <span className="text-destructive">*</span></Label>
+        <IngredientSuggestInput
+          value={form.searchKeywords}
+          onChange={(v) => setForm((f) => ({ ...f, searchKeywords: v }))}
+          placeholder="例: 鶏肉、パスタ、時短…"
+        />
+        <p className="text-xs text-muted-foreground">候補から選んでください（Enter で先頭候補を追加）</p>
+      </div>
+      <div className="space-y-2">
+        <Label>苦手な食材（任意）</Label>
+        <IngredientSuggestInput
+          value={form.dislikedIngredients}
+          onChange={(v) => setForm((f) => ({ ...f, dislikedIngredients: v }))}
+          placeholder="例: セロリ、パクチー…"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>調理時間の希望</Label>
+        <Select value={form.maxCookingMinutes} onValueChange={(v) => setForm((f) => ({ ...f, maxCookingMinutes: v }))}>
+          <SelectTrigger><SelectValue /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">制限なし</SelectItem>
+            <SelectItem value="30">30分以内</SelectItem>
+            <SelectItem value="20">20分以内</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <Button type="submit" className="w-full" disabled={submitting || form.searchKeywords.length === 0}>
+        {submitting ? '送信中…' : 'レシピを探してもらう'}
+      </Button>
+    </form>
+  )
+}
+
+export function PreferencesForm() {
+  const { form, setForm, submitting, submitted, handleSubmit, handleSkip } = usePreferencesForm()
+
+  if (submitted) return <SubmittedView />
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center p-6">
@@ -84,48 +134,7 @@ export function PreferencesForm() {
           <h1 className="text-xl font-bold">好みを教えてください</h1>
           <p className="text-sm text-muted-foreground">あなた向けのレシピを探します</p>
         </div>
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <div className="space-y-2">
-            <Label>好きな食材・料理名 <span className="text-destructive">*</span></Label>
-            <IngredientSuggestInput
-              value={form.searchKeywords}
-              onChange={(v) => setForm((f) => ({ ...f, searchKeywords: v }))}
-              placeholder="例: 鶏肉、パスタ、時短…"
-            />
-            <p className="text-xs text-muted-foreground">候補から選んでください（Enter で先頭候補を追加）</p>
-          </div>
-          <div className="space-y-2">
-            <Label>苦手な食材（任意）</Label>
-            <IngredientSuggestInput
-              value={form.dislikedIngredients}
-              onChange={(v) => setForm((f) => ({ ...f, dislikedIngredients: v }))}
-              placeholder="例: セロリ、パクチー…"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>調理時間の希望</Label>
-            <Select
-              value={form.maxCookingMinutes}
-              onValueChange={(v) => setForm((f) => ({ ...f, maxCookingMinutes: v }))}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">制限なし</SelectItem>
-                <SelectItem value="30">30分以内</SelectItem>
-                <SelectItem value="20">20分以内</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <Button
-            type="submit"
-            className="w-full"
-            disabled={submitting || form.searchKeywords.length === 0}
-          >
-            {submitting ? '送信中…' : 'レシピを探してもらう'}
-          </Button>
-        </form>
+        <PreferencesFormBody form={form} setForm={setForm} submitting={submitting} onSubmit={handleSubmit} />
         <div className="text-center">
           <button type="button" onClick={handleSkip} className="text-xs text-muted-foreground underline">
             スキップして始める

--- a/src/lib/auth/context.tsx
+++ b/src/lib/auth/context.tsx
@@ -16,7 +16,7 @@ interface AuthProviderProps {
   adapter: AuthProviderAdapter
 }
 
-export function AuthProvider({ children, adapter }: AuthProviderProps) {
+function useAuthUser(adapter: AuthProviderAdapter) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -59,10 +59,16 @@ export function AuthProvider({ children, adapter }: AuthProviderProps) {
     }
   }, [adapter])
 
+  return { user, setUser, isLoading, error }
+}
+
+export function AuthProvider({ children, adapter }: AuthProviderProps) {
+  const { user, setUser, isLoading, error } = useAuthUser(adapter)
+
   const logout = useCallback(async () => {
     await adapter.logout()
     setUser(null)
-  }, [adapter])
+  }, [adapter, setUser])
 
   const relogin = useCallback(async () => {
     await adapter.relogin()


### PR DESCRIPTION
## Summary

- Playwright セットアップ（Chromium のみ、`workers=1` で DB 競合防止）
- `dotenv` で `.env.local` を自動ロード（CI は `$GITHUB_ENV` 経由）
- GitHub Actions ワークフロー追加（`main` マージ後 + 手動トリガー、PR 時は不実行）
- Local Supabase を使ったテスト用 DB ヘルパー（`setupUser` / `cleanUserData` / `seedRecipes`）

## テストケース

| spec | 内容 |
|------|------|
| `onboarding-guard.spec.ts` | 新規ユーザーのリダイレクト、完了済みユーザーの通過、`/onboarding` での無限リダイレクト防止 |
| `onboarding.spec.ts` | フルフロー（食材入力→登録→ホーム）、スキップ |

## 設計の決定事項

- **DB**: Local Supabase（ほぼ全フローが DB データを必要とするため mock なし）
- **外部サービス**: Edge Function スクレイピング・Gemini・LINE push は `page.route()` でモック
- **認証**: `NEXT_PUBLIC_LIFF_ID=''` で DevAuth モードを使用

## Test plan

- [ ] `npm run test:e2e` で 5 件全パスを確認
- [ ] `npm run test:e2e:ui` でブラウザ UI から動作確認
- [ ] CI（main マージ後）で自動実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)