### PR TITLE
fix: onboarding_sessions テーブルに RLS を有効化

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,12 +1,15 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-03-24 (Renovate 自動マージ設定追加)
+2026-03-25 (ビルドエラー修正・デプロイ復旧)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **一般公開準備完了**
 
 ## 直近の完了タスク
+- [x] **ビルドエラー修正**（`preferences-form.tsx`）
+  - `usePreferencesForm` が `user` を戻り値に含めていなかったため `SubmittedView lineUserId={user?.lineUserId}` でコンパイルエラー
+  - `d80281b`（ホームへ戻る追加）で混入したバグ。修正 & push 済み（`a79d91f`）
 - [x] **Renovate 自動マージ設定を追加**（`renovate.json`）
   - patch/minor は CI 通過で自動マージ（3日経過後）
   - major・コアフレームワーク（next, react, supabase-js, ai SDK）は手動レビュー
@@ -69,11 +72,11 @@
 
 ## コミット履歴（直近）
 ```
+a79d91f fix: usePreferencesForm から user を返し SubmittedView に渡す
+febc19b docs: update SESSION.md for session handoff
 811261d chore: Renovate の自動マージ設定を追加
 d507067 docs: update SESSION.md for session handoff
 792dbbb fix: playwright-report を ESLint の ignore 対象に追加
-d80281b feat: オンボーディング待ち画面に「ホームへ戻る」を追加
-03d9743 fix: onboarding Edge Function が起動しないバグを修正
 ```
 
 ## GitHubリポジトリ

--- a/supabase/migrations/20260325000000_enable_rls_onboarding_sessions.sql
+++ b/supabase/migrations/20260325000000_enable_rls_onboarding_sessions.sql
@@ -1,0 +1,11 @@
+-- onboarding_sessions テーブルに RLS を有効化
+-- すべてのアクセスは Next.js API / Edge Function 経由でサービスロールキーを使用するため
+-- service_role のみアクセスを許可する
+ALTER TABLE onboarding_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access to onboarding_sessions"
+  ON onboarding_sessions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Supabase のセキュリティ警告（`rls_disabled_in_public`）に対応
- `onboarding_sessions` テーブルに `ENABLE ROW LEVEL SECURITY` を追加
- `service_role` のみ全操作を許可するポリシーを追加（`unmatched_ingredients` と同パターン）

## 背景
`onboarding_sessions` へのアクセスはすべてサーバーサイド（Next.js API Routes / Edge Function）から  
`SUPABASE_SECRET_KEY`（service role）経由で行われる。ブラウザからの直接アクセスはない。

## Test plan
- [ ] ローカル DB へのマイグレーション適用済み（`supabase db push --local`）
- [ ] オンボーディングフローが正常動作すること（API 経由の INSERT/SELECT/UPDATE が service_role で通る）
- [ ] CI（lint & build）が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)