### PR TITLE
feat: オンボーディング食材選択 UI を改善 + 溶き卵マッチ修正

### DIFF
--- a/src/components/features/onboarding/ingredient-chip-selector.tsx
+++ b/src/components/features/onboarding/ingredient-chip-selector.tsx
@@ -27,34 +27,69 @@ function ChipButton({ name, selected, onToggle }: { name: string; selected: bool
   )
 }
 
-function FreeTextInput({ value, onChange }: { value: string[]; onChange: (v: string[]) => void }) {
-  const [input, setInput] = useState('')
+function CategoryTabs({ byCategory, value, onToggle }: {
+  byCategory: Record<string, PopularIngredient[]>
+  value: string[]
+  onToggle: (name: string) => void
+}) {
+  const categories = Object.keys(byCategory)
+  return (
+    <Tabs defaultValue={categories[0]}>
+      <TabsList className="mb-6 h-auto w-full justify-start gap-6 overflow-x-auto border-b bg-transparent p-0">
+        {categories.map((cat) => (
+          <TabsTrigger
+            key={cat}
+            value={cat}
+            className="h-auto flex-none rounded-none border-0 border-b-2 border-transparent bg-transparent px-0 pb-2 transition-colors data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+          >
+            {cat}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {categories.map((cat) => (
+        <TabsContent key={cat} value={cat}>
+          <div className="flex min-h-[200px] flex-wrap content-start gap-2">
+            {byCategory[cat].map((ing) => (
+              <ChipButton
+                key={ing.id}
+                name={ing.name}
+                selected={value.includes(ing.name)}
+                onToggle={() => onToggle(ing.name)}
+              />
+            ))}
+          </div>
+        </TabsContent>
+      ))}
+    </Tabs>
+  )
+}
+
+function useFreeTextCommit(value: string[], onChange: (v: string[]) => void) {
+  const [freeText, setFreeText] = useState('')
   const [isComposing, setIsComposing] = useState(false)
 
-  function addFreeText() {
-    const trimmed = input.trim()
+  function commit() {
+    const trimmed = freeText.trim()
+    setFreeText('')
     if (!trimmed || value.includes(trimmed)) return
     onChange([...value, trimmed])
-    setInput('')
   }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Enter' && !isComposing) {
-      e.preventDefault()
-      addFreeText()
-    }
+  const inputProps = {
+    value: freeText,
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => setFreeText(e.target.value),
+    onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && !isComposing) {
+        e.preventDefault()
+        commit()
+      }
+    },
+    onCompositionStart: () => setIsComposing(true),
+    onCompositionEnd: () => setIsComposing(false),
+    placeholder: '任意の食材を入力',
   }
 
-  return (
-    <Input
-      value={input}
-      onChange={(e) => setInput(e.target.value)}
-      onKeyDown={handleKeyDown}
-      onCompositionStart={() => setIsComposing(true)}
-      onCompositionEnd={() => setIsComposing(false)}
-      placeholder="リストにないものを入力して Enter…"
-    />
-  )
+  return { inputProps, commit }
 }
 
 function IngredientDrawer({
@@ -66,53 +101,33 @@ function IngredientDrawer({
   value: string[]
   onChange: (v: string[]) => void
 }) {
+  const { inputProps, commit } = useFreeTextCommit(value, onChange)
+
   const byCategory = CATEGORY_ORDER.reduce<Record<string, PopularIngredient[]>>((acc, cat) => {
     const items = popularIngredients.filter((i) => i.category === cat)
     if (items.length) acc[cat] = items
     return acc
   }, {})
-  const categories = Object.keys(byCategory)
 
   function toggle(name: string) {
     onChange(value.includes(name) ? value.filter((v) => v !== name) : [...value, name])
   }
 
+  function handleOpenChange(next: boolean) {
+    if (!next) commit()
+    onOpenChange(next)
+  }
+
   return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
+    <Drawer open={open} onOpenChange={handleOpenChange}>
       <DrawerContent>
         <DrawerHeader>
           <DrawerTitle>食材を選ぶ</DrawerTitle>
         </DrawerHeader>
         <div className="flex-1 overflow-y-auto px-4 pb-2">
-          <Tabs defaultValue={categories[0]}>
-            <TabsList className="mb-3 h-auto w-full flex-wrap justify-start gap-1 bg-transparent p-0">
-              {categories.map((cat) => (
-                <TabsTrigger
-                  key={cat}
-                  value={cat}
-                  className="h-auto flex-none rounded-full border px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
-                >
-                  {cat}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-            {categories.map((cat) => (
-              <TabsContent key={cat} value={cat}>
-                <div className="flex flex-wrap gap-2">
-                  {byCategory[cat].map((ing) => (
-                    <ChipButton
-                      key={ing.id}
-                      name={ing.name}
-                      selected={value.includes(ing.name)}
-                      onToggle={() => toggle(ing.name)}
-                    />
-                  ))}
-                </div>
-              </TabsContent>
-            ))}
-          </Tabs>
+          <CategoryTabs byCategory={byCategory} value={value} onToggle={toggle} />
           <div className="mt-4">
-            <FreeTextInput value={value} onChange={onChange} />
+            <Input {...inputProps} />
           </div>
         </div>
         <DrawerFooter>


### PR DESCRIPTION
## Summary
- オンボーディング食材選択 Drawer の UI/UX を改善（カテゴリタブを下線スタイル化、高さ安定化、自由入力の確実なコミット など）
- 「溶き卵」が調味料として除外され卵にマッチしない問題を修正

## 変更内容

### オンボーディング食材選択 UI（c7014b3）
- カテゴリタブを下線スタイルに変更し、フィルター（カテゴリ）と選択肢（食材チップ）の区別を視覚的に明確化
- 横スクロール対応：7カテゴリが幅に収まらない場合でもスワイプで閲覧可能
- 食材エリアに \`min-h-[200px]\` を設定し、カテゴリ切替時の Drawer 高さの変動を抑制
- 完了ボタンを押した際、Enter 未押下の自由入力テキストも自動コミットされるよう修正
- プレースホルダーを「リストにないものを入力して Enter…」→「任意の食材を入力」に変更
- ロジックを \`useFreeTextCommit\` フック / \`CategoryTabs\` コンポーネントに分割

### 溶き卵マッチ修正（ac5b225）
- 「溶き卵」が調味料として除外され卵カテゴリにマッチしない問題を修正

## Test plan
- [ ] スマホ実機（LIFF 経由）でオンボーディング画面を開き、食材選択 Drawer の表示確認
  - [ ] カテゴリタブが下線スタイルで表示される
  - [ ] カテゴリを切り替えても Drawer 全体の高さが大きく変動しない
  - [ ] 自由入力欄にテキストを入力 → Enter を押さずに「完了」 → 入力したテキストがリストに反映される
  - [ ] 自由入力欄にテキストを入力 → 下スワイプで閉じる → 入力したテキストがリストに反映される
- [ ] レシピ登録時、「溶き卵」を含むレシピが卵にマッチすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)