### PR TITLE
fix: LINE食材検索で調理時間・材料数が表示されない問題を修正

### DIFF
--- a/src/lib/line/category-handler.ts
+++ b/src/lib/line/category-handler.ts
@@ -1,6 +1,7 @@
 import { messagingApi } from '@line/bot-sdk'
-import { createVerticalListMessage, RecipeCardData } from './flex-message'
+import { createVerticalListMessage } from './flex-message'
 import { fetchMostViewedForBot, fetchFewIngredientsForBot, fetchShortCookingTimeForBot, fetchRecentlyAddedForBot } from './search-recipes'
+import { toCard } from './recipe-card-mapper'
 
 type MessagingApiClient = messagingApi.MessagingApiClient
 
@@ -74,16 +75,8 @@ export async function handleYokuTsukuru(
       await replyText(client, replyToken, 'まだ閲覧履歴がありません。レシピを見てみましょう！')
       return
     }
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ''
     const liffId = process.env.NEXT_PUBLIC_LIFF_ID || ''
-    const cards: RecipeCardData[] = recipes.map((r) => ({
-      title: r.title,
-      url: `${baseUrl}/api/track/recipe/${r.id}`,
-      imageUrl: r.imageUrl,
-      sourceName: r.sourceName,
-      cookingTimeMinutes: r.cookingTimeMinutes,
-      ingredientCount: r.ingredientCount,
-    }))
+    const cards = recipes.map(toCard)
     const liffUrl = `https://liff.line.me/${liffId}?sort=most_viewed`
     await client.replyMessage({
       replyToken,
@@ -107,16 +100,8 @@ export async function handleShortCookingTime(
       await replyText(client, replyToken, '調理時間が登録されたレシピがまだありません。\nレシピ登録時に自動で取得されます。')
       return
     }
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ''
     const liffId = process.env.NEXT_PUBLIC_LIFF_ID || ''
-    const cards: RecipeCardData[] = recipes.map((r) => ({
-      title: r.title,
-      url: `${baseUrl}/api/track/recipe/${r.id}`,
-      imageUrl: r.imageUrl,
-      sourceName: r.sourceName,
-      cookingTimeMinutes: r.cookingTimeMinutes,
-      ingredientCount: r.ingredientCount,
-    }))
+    const cards = recipes.map(toCard)
     const headerText = '⏱ 短時間で作れるレシピ'
     const liffUrl = `https://liff.line.me/${liffId}?sort=shortest_cooking`
     await client.replyMessage({
@@ -141,16 +126,8 @@ export async function handleFewIngredients(
       await replyText(client, replyToken, 'レシピがまだ登録されていません。\nURLを送ってレシピを保存しましょう！')
       return
     }
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ''
     const liffId = process.env.NEXT_PUBLIC_LIFF_ID || ''
-    const cards: RecipeCardData[] = recipes.map((r) => ({
-      title: r.title,
-      url: `${baseUrl}/api/track/recipe/${r.id}`,
-      imageUrl: r.imageUrl,
-      sourceName: r.sourceName,
-      ingredientCount: r.ingredientCount,
-      cookingTimeMinutes: r.cookingTimeMinutes,
-    }))
+    const cards = recipes.map(toCard)
     const headerText = '📦 材料少なめで作れるレシピ'
     const liffUrl = `https://liff.line.me/${liffId}?sort=fewest_ingredients`
     await client.replyMessage({
@@ -175,16 +152,8 @@ export async function handleRecentlyAdded(
       await replyText(client, replyToken, 'まだレシピが登録されていません。\nURLを送ってレシピを保存しましょう！')
       return
     }
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || ''
     const liffId = process.env.NEXT_PUBLIC_LIFF_ID || ''
-    const cards: RecipeCardData[] = recipes.map((r) => ({
-      title: r.title,
-      url: `${baseUrl}/api/track/recipe/${r.id}`,
-      imageUrl: r.imageUrl,
-      sourceName: r.sourceName,
-      cookingTimeMinutes: r.cookingTimeMinutes,
-      ingredientCount: r.ingredientCount,
-    }))
+    const cards = recipes.map(toCard)
     const liffUrl = `https://liff.line.me/${liffId}?sort=newest`
     await client.replyMessage({
       replyToken,

--- a/src/lib/line/recipe-card-mapper.ts
+++ b/src/lib/line/recipe-card-mapper.ts
@@ -1,0 +1,12 @@
+import type { RecipeCardData } from './flex-message'
+import type { SearchRecipeResult } from './search-recipes'
+
+/** SearchRecipeResult → RecipeCardData 変換（LINE Flex Message 用） */
+export const toCard = (r: SearchRecipeResult): RecipeCardData => ({
+  title: r.title,
+  url: `${process.env.NEXT_PUBLIC_APP_URL || ''}/api/track/recipe/${r.id}`,
+  imageUrl: r.imageUrl,
+  sourceName: r.sourceName,
+  cookingTimeMinutes: r.cookingTimeMinutes,
+  ingredientCount: r.ingredientCount,
+})

--- a/src/lib/line/search-handler.ts
+++ b/src/lib/line/search-handler.ts
@@ -20,6 +20,8 @@ const toCard = (r: SearchRecipeResult): RecipeCardData => ({
   url: `${process.env.NEXT_PUBLIC_APP_URL || ''}/api/track/recipe/${r.id}`,
   imageUrl: r.imageUrl,
   sourceName: r.sourceName,
+  cookingTimeMinutes: r.cookingTimeMinutes,
+  ingredientCount: r.ingredientCount,
 })
 
 /** 最近見たキーワードかどうかを判定 */

--- a/src/lib/line/search-handler.ts
+++ b/src/lib/line/search-handler.ts
@@ -1,8 +1,9 @@
 import { messagingApi } from '@line/bot-sdk'
-import { createVerticalListMessage, RecipeCardData } from './flex-message'
+import { createVerticalListMessage } from './flex-message'
 import { parseSearchQuery, ParsedSearchQuery } from './parse-search-query'
 import { searchRecipesForBot, fetchRecentlyViewedForBot, fetchMostViewedForBot, SearchRecipeResult } from './search-recipes'
 import { buildIngredientQuickReply } from './quick-reply'
+import { toCard } from './recipe-card-mapper'
 
 type MessagingApiClient = messagingApi.MessagingApiClient
 type ReplyParams = { client: MessagingApiClient; replyToken: string }
@@ -15,14 +16,6 @@ export function isIngredientSearchKeyword(text: string): boolean {
   return INGREDIENT_SEARCH_KEYWORDS.includes(normalizedText)
 }
 
-const toCard = (r: SearchRecipeResult): RecipeCardData => ({
-  title: r.title,
-  url: `${process.env.NEXT_PUBLIC_APP_URL || ''}/api/track/recipe/${r.id}`,
-  imageUrl: r.imageUrl,
-  sourceName: r.sourceName,
-  cookingTimeMinutes: r.cookingTimeMinutes,
-  ingredientCount: r.ingredientCount,
-})
 
 /** 最近見たキーワードかどうかを判定 */
 export function isRecentlyViewedKeyword(text: string): boolean {

--- a/src/lib/line/search-recipes.ts
+++ b/src/lib/line/search-recipes.ts
@@ -81,7 +81,7 @@ export async function searchRecipesForBot(
   if (!query.searchQuery.trim()) {
     let recipesQuery = supabase
       .from('recipes')
-      .select('id, title, url, image_url, source_name')
+      .select('id, title, url, image_url, source_name, cooking_time_minutes, ingredients_raw')
       .eq('user_id', user.id)
       .order('created_at', { ascending: false })
       .limit(limit)
@@ -91,15 +91,15 @@ export async function searchRecipesForBot(
     const { data: recipes } = await recipesQuery
     if (!recipes) return []
 
-    return recipes.map((r) => ({ id: r.id, title: r.title, url: r.url, imageUrl: r.image_url, sourceName: r.source_name }))
+    return recipes.map(toResult)
   }
 
   // ハイブリッド検索
   return searchRecipesHybridForBot(supabase, user.id, query.searchQuery.trim(), recipeIds, limit)
 }
 
-type RecipeRow = { id: string; title: string; url: string; image_url: string | null; source_name: string | null }
-const toResult = (r: RecipeRow): SearchRecipeResult => ({ id: r.id, title: r.title, url: r.url, imageUrl: r.image_url, sourceName: r.source_name })
+type RecipeRow = { id: string; title: string; url: string; image_url: string | null; source_name: string | null; cooking_time_minutes: number | null; ingredients_raw: unknown }
+const toResult = (r: RecipeRow): SearchRecipeResult => ({ id: r.id, title: r.title, url: r.url, imageUrl: r.image_url, sourceName: r.source_name, cookingTimeMinutes: r.cooking_time_minutes, ingredientCount: Array.isArray(r.ingredients_raw) ? r.ingredients_raw.length : null })
 
 /** 最近見たレシピ（last_viewed_at DESC, NULL除外） */
 export async function fetchRecentlyViewedForBot(lineUserId: string, limit = 5): Promise<SearchRecipeResult[]> {
@@ -109,7 +109,7 @@ export async function fetchRecentlyViewedForBot(lineUserId: string, limit = 5): 
 
   const { data } = await supabase
     .from('recipes')
-    .select('id, title, url, image_url, source_name')
+    .select('id, title, url, image_url, source_name, cooking_time_minutes, ingredients_raw')
     .eq('user_id', user.id)
     .not('last_viewed_at', 'is', null)
     .order('last_viewed_at', { ascending: false })
@@ -205,7 +205,7 @@ async function searchRecipesHybridForBot(
   supabase: ReturnType<typeof createServerClient>, userId: string, searchQuery: string, recipeIds: string[] | null, limit: number
 ): Promise<SearchRecipeResult[]> {
   const term = `%${searchQuery}%`
-  let q = supabase.from('recipes').select('id, title, url, image_url, source_name').eq('user_id', userId)
+  let q = supabase.from('recipes').select('id, title, url, image_url, source_name, cooking_time_minutes, ingredients_raw').eq('user_id', userId)
     .or(`title.ilike.${term},memo.ilike.${term},source_name.ilike.${term}`).order('created_at', { ascending: false }).limit(limit)
   if (recipeIds !== null) q = q.in('id', recipeIds)
   const { data } = await q
@@ -217,7 +217,7 @@ async function searchRecipesHybridForBot(
     const additionalIds = await getVectorSearchIds(supabase, userId, searchQuery, excludeIds, limit)
     const filteredIds = recipeIds ? additionalIds.filter((id) => recipeIds.includes(id)) : additionalIds
     if (filteredIds.length > 0) {
-      const { data: extra } = await supabase.from('recipes').select('id, title, url, image_url, source_name').in('id', filteredIds)
+      const { data: extra } = await supabase.from('recipes').select('id, title, url, image_url, source_name, cooking_time_minutes, ingredients_raw').in('id', filteredIds)
       return [...results, ...(extra ?? []).map(toResult)]
     }
   } catch (e) { console.error('[searchRecipesHybridForBot] Vector search failed:', e) }


### PR DESCRIPTION
searchRecipesForBot / searchRecipesHybridForBot の SELECT に cooking_time_minutes, ingredients_raw を追加し、toResult で統一的にマッピング。 fetchRecentlyViewedForBot も同様に修正。

Closes #34