### PR TITLE
fix: オンボーディング一括登録で食材リンクとサイト名が登録されない問題を修正 (Issue #49)

### DIFF
--- a/src/app/api/onboarding/complete/route.ts
+++ b/src/app/api/onboarding/complete/route.ts
@@ -1,10 +1,12 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest, NextResponse, after } from 'next/server'
 import { createServerClient } from '@/lib/db/client'
 import type { Json, TablesInsert } from '@/types/database'
+import { linkIngredientsForRecipes } from '@/lib/recipe/link-ingredients'
 
 interface RecipeCandidate {
   url: string
   title: string
+  sourceName?: string
   imageUrl?: string
   cookingTimeMinutes?: number | null
   ingredientsRaw?: { name: string; amount: string }[]
@@ -37,15 +39,24 @@ export async function POST(request: NextRequest) {
       user_id: user.id,
       url: c.url,
       title: c.title,
+      source_name: c.sourceName ?? null,
       image_url: c.imageUrl ?? null,
       cooking_time_minutes: c.cookingTimeMinutes ?? null,
       ingredients_raw: (c.ingredientsRaw ?? []) as unknown as Json,
       ingredients_linked: false,
     }))
 
-    const { error } = await supabase.from('recipes').insert(rows)
+    const { data: inserted, error } = await supabase.from('recipes').insert(rows).select('id, ingredients_raw')
     if (error) {
       console.error('[onboarding/complete] Bulk insert error:', error)
+    }
+
+    if (inserted && inserted.length > 0) {
+      const recipesToLink = inserted.map((r) => ({
+        id: r.id,
+        ingredientsRaw: (r.ingredients_raw ?? []) as { name: string; amount: string }[],
+      }))
+      after(() => linkIngredientsForRecipes(recipesToLink))
     }
   }
 

--- a/src/components/features/onboarding/recipe-candidates.tsx
+++ b/src/components/features/onboarding/recipe-candidates.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/lib/auth'
 interface RecipeCandidate {
   url: string
   title: string
+  sourceName?: string
   imageUrl: string
   cookingTimeMinutes: number | null
   ingredientsRaw: { name: string; amount: string }[]

--- a/src/lib/recipe/link-ingredients.ts
+++ b/src/lib/recipe/link-ingredients.ts
@@ -1,0 +1,51 @@
+import { createServerClient } from '@/lib/db/client'
+import type { TablesInsert } from '@/types/database'
+import { matchIngredientsForRecipes } from './match-ingredients'
+
+interface RecipeToLink {
+  id: string
+  ingredientsRaw: { name: string; amount: string }[]
+}
+
+/**
+ * ingredients_linked: false のレシピに対して食材マッチングを実行し、
+ * recipe_ingredients を挿入して ingredients_linked を true に更新する。
+ *
+ * DB クエリは ingredients/aliases の一括フェッチ2回 + レシピ数分の insert/update のみ。
+ */
+export async function linkIngredientsForRecipes(recipes: RecipeToLink[]): Promise<void> {
+  if (recipes.length === 0) return
+
+  const supabase = createServerClient()
+
+  const input = recipes.map((r) => ({
+    recipeId: r.id,
+    ingredientNames: r.ingredientsRaw.map((i) => i.name),
+  }))
+
+  const matchResultMap = await matchIngredientsForRecipes(input)
+
+  for (const recipe of recipes) {
+    const matched = matchResultMap.get(recipe.id) ?? []
+
+    if (matched.length > 0) {
+      const rows: TablesInsert<'recipe_ingredients'>[] = matched.map((m) => ({
+        recipe_id: recipe.id,
+        ingredient_id: m.ingredientId,
+        is_main: true,
+      }))
+      const { error: insertError } = await supabase.from('recipe_ingredients').insert(rows)
+      if (insertError) {
+        console.error(`[linkIngredients] insert error for recipe ${recipe.id}:`, insertError)
+      }
+    }
+
+    const { error: updateError } = await supabase
+      .from('recipes')
+      .update({ ingredients_linked: matched.length > 0 })
+      .eq('id', recipe.id)
+    if (updateError) {
+      console.error(`[linkIngredients] update error for recipe ${recipe.id}:`, updateError)
+    }
+  }
+}

--- a/src/lib/recipe/match-ingredients.ts
+++ b/src/lib/recipe/match-ingredients.ts
@@ -41,57 +41,50 @@ interface Ingredient {
   name: string
 }
 
-interface IngredientAlias {
-  ingredient_id: string
-}
-
 type TypedSupabaseClient = SupabaseClient<Database>
 
 /**
- * レビュー済みのマスター食材を全て取得
+ * 1食材を処理してマッチ結果を results に追加する。
+ * アンマッチの場合は未マッチ記録用の normalizedName を返す。
  */
-async function fetchAllIngredients(supabase: TypedSupabaseClient): Promise<Ingredient[]> {
-  const { data } = await supabase
-    .from('ingredients')
-    .select('id, name')
-    .eq('needs_review', false)
-
-  return (data ?? []) as Ingredient[]
+function processSingleName(
+  name: string,
+  allIngredients: Ingredient[],
+  ingredientIdMap: Map<string, Ingredient>,
+  aliasMap: Map<string, string>,
+  seen: Set<string>,
+  results: MatchResult[],
+): string | null {
+  if (!name.trim()) return null
+  const normalizedName = normalizeIngredientName(name)
+  const matched = matchSingleIngredient(allIngredients, ingredientIdMap, aliasMap, name)
+  if (matched && !seen.has(matched.id)) {
+    seen.add(matched.id)
+    results.push({ ingredientId: matched.id, name: matched.name })
+    return null
+  }
+  if (!matched && normalizedName && !isSeasoning(normalizedName)) {
+    return normalizedName
+  }
+  return null
 }
 
-async function findByAlias(
-  supabase: TypedSupabaseClient,
-  name: string
-): Promise<Ingredient | null> {
-  const { data: aliasRows } = await supabase
-    .from('ingredient_aliases')
-    .select('ingredient_id')
-    .eq('alias', name)
-    .limit(1)
+/** ingredients と ingredient_aliases を一括フェッチしてインメモリ検索用データを構築 */
+async function fetchIngredientMaps(supabase: TypedSupabaseClient): Promise<{
+  allIngredients: Ingredient[]
+  aliasMap: Map<string, string>  // alias → ingredient_id
+}> {
+  const [{ data: ingredientsData }, { data: aliasesData }] = await Promise.all([
+    supabase.from('ingredients').select('id, name').eq('needs_review', false),
+    supabase.from('ingredient_aliases').select('alias, ingredient_id'),
+  ])
 
-  const aliasRow = (aliasRows as IngredientAlias[] | null)?.[0]
-  if (!aliasRow) return null
+  const allIngredients = (ingredientsData ?? []) as Ingredient[]
+  const aliasMap = new Map<string, string>(
+    (aliasesData ?? []).map((row) => [row.alias as string, row.ingredient_id as string])
+  )
 
-  const { data: ingredientRows } = await supabase
-    .from('ingredients')
-    .select('id, name')
-    .eq('id', aliasRow.ingredient_id)
-    .limit(1)
-
-  return (ingredientRows as Ingredient[] | null)?.[0] ?? null
-}
-
-async function findByExactMatch(
-  supabase: TypedSupabaseClient,
-  name: string
-): Promise<Ingredient | null> {
-  const { data: rows } = await supabase
-    .from('ingredients')
-    .select('id, name')
-    .eq('name', name)
-    .limit(1)
-
-  return (rows as Ingredient[] | null)?.[0] ?? null
+  return { allIngredients, aliasMap }
 }
 
 /**
@@ -108,10 +101,9 @@ function findByPartialMatch(
   normalizedName: string
 ): Ingredient | null {
   // 1. マスター食材名が入力に含まれる（最長優先）
-  // 例: 「豚肉細切れ」.includes(「豚肉」) → true
   const containedMatches = allIngredients
     .filter((ing) => normalizedName.includes(ing.name))
-    .sort((a, b) => b.name.length - a.name.length) // 長い順
+    .sort((a, b) => b.name.length - a.name.length)
 
   // 最低2文字以上のマッチを要求（「肉」だけでマッチしないように）
   if (containedMatches.length > 0 && containedMatches[0].name.length >= 2) {
@@ -119,10 +111,9 @@ function findByPartialMatch(
   }
 
   // 2. 入力がマスター食材名に含まれる（最短優先）
-  // 例: 「豚肉」.includes(「豚」) → true
   const includingMatches = allIngredients
     .filter((ing) => ing.name.includes(normalizedName))
-    .sort((a, b) => a.name.length - b.name.length) // 短い順
+    .sort((a, b) => a.name.length - b.name.length)
 
   if (includingMatches.length > 0) {
     return includingMatches[0]
@@ -147,12 +138,12 @@ async function recordUnmatchedIngredient(
   })
 }
 
-async function matchSingleIngredient(
-  supabase: TypedSupabaseClient,
+function matchSingleIngredient(
   allIngredients: Ingredient[],
-  rawName: string,
-  recipeId?: string
-): Promise<MatchResult | null> {
+  ingredientIdMap: Map<string, Ingredient>,
+  aliasMap: Map<string, string>,
+  rawName: string
+): Ingredient | null {
   // Step 0: 正規化（分量・単位を除去）
   const normalizedName = normalizeIngredientName(rawName)
   if (!normalizedName) return null
@@ -160,32 +151,19 @@ async function matchSingleIngredient(
   // Step 0.5: 調味料は除外（マッチ対象外）
   if (isSeasoning(normalizedName)) return null
 
-  // Step 1: エイリアス検索
-  const aliasMatch = await findByAlias(supabase, normalizedName)
-  if (aliasMatch) {
-    return { ingredientId: aliasMatch.id, name: aliasMatch.name }
+  // Step 1: エイリアス検索（インメモリ）
+  const aliasedId = aliasMap.get(normalizedName)
+  if (aliasedId) {
+    const ing = ingredientIdMap.get(aliasedId)
+    if (ing) return ing
   }
 
-  // Step 2: 完全一致検索
-  const exactMatch = await findByExactMatch(supabase, normalizedName)
-  if (exactMatch) {
-    return { ingredientId: exactMatch.id, name: exactMatch.name }
-  }
+  // Step 2: 完全一致検索（インメモリ）
+  const exactMatch = allIngredients.find((ing) => ing.name === normalizedName) ?? null
+  if (exactMatch) return exactMatch
 
-  // Step 3: 部分一致検索
-  const partialMatch = findByPartialMatch(allIngredients, normalizedName)
-  if (partialMatch) {
-    return {
-      ingredientId: partialMatch.id,
-      name: partialMatch.name,
-    }
-  }
-
-  // Step 4: 未マッチを記録（ingredientsには追加しない）
-  // → 後からエイリアス登録やLLMフォールバックの判断材料に
-  await recordUnmatchedIngredient(supabase, rawName, normalizedName, recipeId)
-
-  return null
+  // Step 3: 部分一致検索（インメモリ）
+  return findByPartialMatch(allIngredients, normalizedName)
 }
 
 export async function matchIngredients(
@@ -196,25 +174,68 @@ export async function matchIngredients(
 
   const supabase = createServerClient()
 
-  // マスター食材を一度だけ取得して使い回す
-  const allIngredients = await fetchAllIngredients(supabase)
+  // ingredients と aliases を2クエリで一括取得
+  const { allIngredients, aliasMap } = await fetchIngredientMaps(supabase)
+
+  // id → ingredient の Map（エイリアス解決用）
+  const ingredientIdMap = new Map<string, Ingredient>(
+    allIngredients.map((ing) => [ing.id, ing])
+  )
 
   const results: MatchResult[] = []
   const seen = new Set<string>()
-  for (const name of ingredientNames) {
-    if (!name.trim()) continue
+  const unmatchedPromises: Promise<void>[] = []
 
-    const result = await matchSingleIngredient(
-      supabase,
-      allIngredients,
-      name,
-      options.recipeId
-    )
-    if (result && !seen.has(result.ingredientId)) {
-      seen.add(result.ingredientId)
-      results.push(result)
+  for (const name of ingredientNames) {
+    const unmatched = processSingleName(name, allIngredients, ingredientIdMap, aliasMap, seen, results)
+    if (unmatched) {
+      unmatchedPromises.push(
+        recordUnmatchedIngredient(supabase, name, unmatched, options.recipeId)
+      )
     }
   }
 
+  if (unmatchedPromises.length > 0) {
+    await Promise.all(unmatchedPromises)
+  }
+
   return results
+}
+
+/** 複数レシピ分を一括でマッチングする（DBクエリを2回のみに抑える） */
+export async function matchIngredientsForRecipes(
+  recipes: Array<{ recipeId: string; ingredientNames: string[] }>
+): Promise<Map<string, MatchResult[]>> {
+  const supabase = createServerClient()
+
+  const { allIngredients, aliasMap } = await fetchIngredientMaps(supabase)
+
+  const ingredientIdMap = new Map<string, Ingredient>(
+    allIngredients.map((ing) => [ing.id, ing])
+  )
+
+  const unmatchedPromises: Promise<void>[] = []
+  const resultMap = new Map<string, MatchResult[]>()
+
+  for (const { recipeId, ingredientNames } of recipes) {
+    const results: MatchResult[] = []
+    const seen = new Set<string>()
+
+    for (const name of ingredientNames) {
+      const unmatched = processSingleName(name, allIngredients, ingredientIdMap, aliasMap, seen, results)
+      if (unmatched) {
+        unmatchedPromises.push(
+          recordUnmatchedIngredient(supabase, name, unmatched, recipeId)
+        )
+      }
+    }
+
+    resultMap.set(recipeId, results)
+  }
+
+  if (unmatchedPromises.length > 0) {
+    await Promise.all(unmatchedPromises)
+  }
+
+  return resultMap
 }

--- a/supabase/functions/onboarding-scrape/index.ts
+++ b/supabase/functions/onboarding-scrape/index.ts
@@ -38,6 +38,7 @@ interface Preferences {
 interface RecipeCandidate {
   url: string
   title: string
+  sourceName: string
   imageUrl: string
   cookingTimeMinutes: number | null
   ingredientsRaw: { name: string; amount: string }[]
@@ -75,6 +76,19 @@ function parseIso8601Duration(v: unknown): number | null {
   return total > 0 ? total : null
 }
 
+function extractSourceName(publisher: unknown, url: string): string {
+  if (typeof publisher === 'string' && publisher) return publisher
+  if (publisher && typeof publisher === 'object' && 'name' in publisher) {
+    const name = (publisher as Record<string, unknown>).name
+    if (typeof name === 'string' && name) return name
+  }
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
 function extractImageUrl(image: unknown): string {
   if (!image) return ''
   if (typeof image === 'string') return image
@@ -103,6 +117,7 @@ function extractJsonLdRecipe(html: string, sourceUrl: string): RecipeCandidate |
         return {
           url: sourceUrl,
           title: recipe.name,
+          sourceName: extractSourceName(recipe.publisher, sourceUrl),
           imageUrl: extractImageUrl(recipe.image),
           cookingTimeMinutes: cookTime ?? null,
           ingredientsRaw: ingredients.map((name: string) => ({ name, amount: '' })),


### PR DESCRIPTION
## Summary

- オンボーディングの一括登録後、`after()` でバックグラウンドに食材マッチング＆`recipe_ingredients`挿入を実行するよう修正
- `match-ingredients.ts` を N+1 解消（ingredients/aliases を2クエリ一括フェッチしインメモリで解決）
- `matchIngredientsForRecipes()` を新規追加（複数レシピを DBクエリ2回で処理）
- `link-ingredients.ts` を新規追加（一括リンク処理）
- `onboarding-scrape` で JSON-LD の `publisher` から `source_name` を抽出・保存するよう修正

## Root Cause

オンボーディングの `complete/route.ts` では `recipe_ingredients` への挿入と `matchIngredients()` の呼び出しが一切なかったため、食材リンクが作成されていなかった。また `source_name` もフロントに渡されていたが保存されていなかった。

## Test plan

- [ ] オンボーディングを完了し、登録されたレシピの食材フィルタが機能することを確認
- [ ] レシピ一覧でサイト名（クラシル / DELISH KITCHEN）が表示されることを確認
- [ ] 通常のレシピ登録・再取得フローが引き続き正常に動作することを確認

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)