### PR TITLE
fix: onboarding結果通知のLIFF URLを修正 (#61)

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,18 +1,22 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-05-16 (Node.js v24 LTS アップグレード完了)
+2026-05-17 (Next.js コアパッケージ更新完了)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **本番稼働中**
 
 ## 直近の完了タスク
+- [x] **Next.js コアパッケージ更新（PR #64）**
+  - next: 16.1.1 → 16.2.6（セキュリティ修正含む）
+  - eslint-config-next: 16.1.1 → 16.2.6
+  - react: 19.2.3 → 19.2.6
+  - react-dom: 19.2.3 → 19.2.6
+  - @types/react: 19.2.8 → 19.2.14
+  - develop にマージ済み
 - [x] **Node.js v24 LTS へのアップグレード（PR #62）**
   - `@types/node`: 20.19.29 → 24.12.4
   - `.nvmrc` を追加（`24`）
-  - fnm（Fast Node Manager）をローカルに導入
-  - ローカルの古い Node.js v22（`/usr/local/bin/node`）を削除
-  - Vercel の Node.js バージョンは Dashboard から設定が必要（Settings → Build & Development Settings → Node.js Version → 24.x）
   - develop にマージ済み
 - [x] **ドキュメント整合性チェック（前セッション）**
 - [x] **#43 / #44 / #49**: OGP 画像、Security Headers、食材リンク修正
@@ -21,9 +25,13 @@
 なし
 
 ## 次にやること（GitHub Issues で管理）
+- [ ] **PR #64 を develop → main へマージして本番リリース**（セキュリティ修正含むため早期推奨）
 - [ ] **Vercel Dashboard で Node.js バージョンを 24.x に設定**（手動作業）
   - Settings → Build & Development Settings → Node.js Version → 24.x
-- [ ] **develop → main PR を作成して本番リリース**（#44, #49, #43, Node.js v24 の変更を本番反映）
+- [ ] **develop → main PR を作成して本番リリース**（#44, #49, #43, Node.js v24, Next.js コア更新を本番反映）
+- [ ] **パッケージアップデートの継続**（スキップした項目）
+  - `@types/node`: 24 → 25（major、影響調査が必要）
+  - G2〜G7 グループのパッケージ
 - [ ] **#45: Vercel Analytics / Speed Insights の導入**
 - [ ] **#37〜#39: E2E テスト**
 
@@ -44,21 +52,22 @@
 - **fnm の PATH:** ターミナル起動時に `eval "$(fnm env --use-on-cd --shell zsh)"` が必要（`~/.zshrc` に設定済み）
 - **husky の npx:** fnm の PATH が通っていないと pre-commit フックが失敗する（`eval "$(fnm env --shell zsh)"` を先に実行）
 - **#48 画像ホットリンク:** 利用規模が数百人規模になったら `next/image` + ワイルドカード許可を再検討
+- **`@types/node` メジャーアップ保留:** 24 → 25 は影響調査が必要なため今回スキップ
 
 ## 参照すべきファイル
 - `CLAUDE.md` - プロジェクトガイド
 - `docs/ARCHITECTURE.md` - アーキテクチャ全体像・ブランチ戦略
 - `docs/DATABASE_DESIGN.md` - DB設計（RPC関数一覧含む）
 - `.nvmrc` - Node.js バージョン指定（24）
-- `package.json` - `@types/node@24.12.4`
+- `package.json` - 各パッケージバージョン
 
 ## コミット履歴（直近）
 ```
+c4f22a4 Merge pull request #64 from mktu/feature/update-nextjs-core-libs
+8b7a325 chore: update Next.js core packages
+04b5afc docs: update SESSION.md for session handoff
 f20da76 Merge pull request #62 from mktu/feature/update-nodejs-24
 1309382 fix: remove invalid vercel.json
-b66904c chore: upgrade Node.js to v24 LTS
-5f2eb4c feat: add update-packages skill and disable Renovate
-b08f211 docs: update SESSION.md for session handoff
 ```
 
 ## GitHubリポジトリ

--- a/src/app/api/onboarding/start/route.ts
+++ b/src/app/api/onboarding/start/route.ts
@@ -12,6 +12,12 @@ interface StartRequestBody {
   preferences: OnboardingPreferences
 }
 
+function buildResultUrl(): string {
+  const liffId = process.env.NEXT_PUBLIC_LIFF_ID
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? ''
+  return liffId ? `https://liff.line.me/${liffId}/onboarding/result` : `${appUrl}/onboarding/result`
+}
+
 export async function POST(request: NextRequest) {
   const body = await request.json() as StartRequestBody
   const { lineUserId, preferences } = body
@@ -57,7 +63,7 @@ export async function POST(request: NextRequest) {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${supabaseKey}`,
       },
-      body: JSON.stringify({ sessionId: session.id }),
+      body: JSON.stringify({ sessionId: session.id, resultUrl: buildResultUrl() }),
     }).catch((err) => {
       console.error('[onboarding/start] Edge Function kick failed:', err)
     })

--- a/supabase/functions/onboarding-scrape/index.ts
+++ b/supabase/functions/onboarding-scrape/index.ts
@@ -281,14 +281,11 @@ async function scrapeAndNotify(sessionId: string, resultUrl: string): Promise<vo
 Deno.serve(async (req) => {
   const { sessionId, resultUrl } = await req.json() as { sessionId: string; resultUrl?: string }
 
-  if (!sessionId) {
-    return new Response(JSON.stringify({ error: 'Missing sessionId' }), { status: 400 })
+  if (!sessionId || !resultUrl) {
+    return new Response(JSON.stringify({ error: 'Missing sessionId or resultUrl' }), { status: 400 })
   }
 
-  const appUrl = Deno.env.get('APP_URL') ?? 'https://localhost:3000'
-  const resolvedResultUrl = resultUrl ?? `${appUrl}/onboarding/result`
-
-  EdgeRuntime.waitUntil(scrapeAndNotify(sessionId, resolvedResultUrl))
+  EdgeRuntime.waitUntil(scrapeAndNotify(sessionId, resultUrl))
 
   return new Response(JSON.stringify({ status: 'processing' }), {
     status: 200,

--- a/supabase/functions/onboarding-scrape/index.ts
+++ b/supabase/functions/onboarding-scrape/index.ts
@@ -190,14 +190,12 @@ function filterCandidates(candidates: RecipeCandidate[], prefs: Preferences): Re
   })
 }
 
-async function sendLineNotification(lineUserId: string, candidateCount: number, appUrl: string): Promise<void> {
+async function sendLineNotification(lineUserId: string, candidateCount: number, resultUrl: string): Promise<void> {
   const token = Deno.env.get('LINE_CHANNEL_ACCESS_TOKEN')
   if (!token) {
     console.warn('[onboarding-scrape] LINE_CHANNEL_ACCESS_TOKEN not set')
     return
   }
-
-  const resultUrl = `${appUrl}/onboarding/result`
 
   const message = candidateCount > 0
     ? {
@@ -238,10 +236,9 @@ async function sendLineNotification(lineUserId: string, candidateCount: number, 
   })
 }
 
-async function scrapeAndNotify(sessionId: string): Promise<void> {
+async function scrapeAndNotify(sessionId: string, resultUrl: string): Promise<void> {
   const supabaseUrl = Deno.env.get('SUPABASE_URL')!
   const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-  const appUrl = Deno.env.get('APP_URL') ?? 'https://localhost:3000'
 
   const supabase = createClient(supabaseUrl, supabaseKey)
 
@@ -273,22 +270,25 @@ async function scrapeAndNotify(sessionId: string): Promise<void> {
       .update({ candidates: all as unknown as any, status: 'completed' })
       .eq('id', sessionId)
 
-    await sendLineNotification(session.user_id, all.length, appUrl)
+    await sendLineNotification(session.user_id, all.length, resultUrl)
   } catch (e) {
     console.error('[onboarding-scrape] Failed:', e)
     await supabase.from('onboarding_sessions').update({ status: 'failed' }).eq('id', sessionId)
-    await sendLineNotification(session.user_id, 0, appUrl)
+    await sendLineNotification(session.user_id, 0, resultUrl)
   }
 }
 
 Deno.serve(async (req) => {
-  const { sessionId } = await req.json() as { sessionId: string }
+  const { sessionId, resultUrl } = await req.json() as { sessionId: string; resultUrl?: string }
 
   if (!sessionId) {
     return new Response(JSON.stringify({ error: 'Missing sessionId' }), { status: 400 })
   }
 
-  EdgeRuntime.waitUntil(scrapeAndNotify(sessionId))
+  const appUrl = Deno.env.get('APP_URL') ?? 'https://localhost:3000'
+  const resolvedResultUrl = resultUrl ?? `${appUrl}/onboarding/result`
+
+  EdgeRuntime.waitUntil(scrapeAndNotify(sessionId, resolvedResultUrl))
 
   return new Response(JSON.stringify({ status: 'processing' }), {
     status: 200,


### PR DESCRIPTION
## Summary

- LINE 通知ボタンのURLがアプリ直接URLになっていたため、LIFF コンテキスト外で開かれ `lineUserId` が取得できず「確認中」のまま固まる不具合を修正
- `/api/onboarding/start` が `NEXT_PUBLIC_LIFF_ID` から LIFF URL (`https://liff.line.me/{liffId}/onboarding/result`) を組み立て、Edge Function に渡すよう変更
- `onboarding-scrape` Edge Function は `resultUrl` をリクエストボディから受け取る（`APP_URL` 環境変数へのフォールバックあり）

## Root cause

`onboarding-scrape` が LINE 通知に使う URL を `${APP_URL}/onboarding/result` で固定生成していた。
この URL を LINE アプリでタップすると LIFF 初期化が正常に動作せず `user?.lineUserId === undefined` となり、
`useOnboardingSession` hook が fetch をスキップして `session` が `undefined` のまま → "確認中..." が永続。

## Test plan

- [ ] オンボーディングフォームを送信 → LINE 通知を受信
- [ ] 通知の「確認する」ボタンをタップ → LIFF で正常に開き、レシピ候補が表示される（または「見つかりませんでした」）
- [ ] 「確認中...」のまま固まらないことを確認

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)