### PR TITLE
chore: update LINE SDK packages

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,34 +1,30 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-05-17 (Next.js コアパッケージ更新完了)
+2026-05-17 (Issue #61 オンボーディング「確認中」固まる不具合を修正)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **本番稼働中**
 
 ## 直近の完了タスク
+- [x] **#61 オンボーディング結果が「確認中」のまま固まる不具合修正（PR #67）**
+  - 根本原因: Edge Function が LINE 通知に直接 URL を使っていたため LIFF 認証が失敗
+  - 修正: `/api/onboarding/start` で LIFF URL を組み立てて Edge Function に渡すよう変更
+  - `onboarding-scrape` の `resultUrl` を必須パラメータ化・`APP_URL` フォールバック削除
+  - `docs/EDGE_FUNCTIONS.md` のドキュメントも更新済み
+  - develop にマージ済み
 - [x] **Next.js コアパッケージ更新（PR #64）**
-  - next: 16.1.1 → 16.2.6（セキュリティ修正含む）
-  - eslint-config-next: 16.1.1 → 16.2.6
-  - react: 19.2.3 → 19.2.6
-  - react-dom: 19.2.3 → 19.2.6
-  - @types/react: 19.2.8 → 19.2.14
   - develop にマージ済み
 - [x] **Node.js v24 LTS へのアップグレード（PR #62）**
-  - `@types/node`: 20.19.29 → 24.12.4
-  - `.nvmrc` を追加（`24`）
   - develop にマージ済み
-- [x] **ドキュメント整合性チェック（前セッション）**
-- [x] **#43 / #44 / #49**: OGP 画像、Security Headers、食材リンク修正
 
 ## 進行中のタスク
 なし
 
 ## 次にやること（GitHub Issues で管理）
-- [ ] **PR #64 を develop → main へマージして本番リリース**（セキュリティ修正含むため早期推奨）
+- [ ] **develop → main PR を作成して本番リリース**（#61 修正、Next.js 更新、Node.js v24 を本番反映）
 - [ ] **Vercel Dashboard で Node.js バージョンを 24.x に設定**（手動作業）
   - Settings → Build & Development Settings → Node.js Version → 24.x
-- [ ] **develop → main PR を作成して本番リリース**（#44, #49, #43, Node.js v24, Next.js コア更新を本番反映）
 - [ ] **パッケージアップデートの継続**（スキップした項目）
   - `@types/node`: 24 → 25（major、影響調査が必要）
   - G2〜G7 グループのパッケージ
@@ -53,21 +49,23 @@
 - **husky の npx:** fnm の PATH が通っていないと pre-commit フックが失敗する（`eval "$(fnm env --shell zsh)"` を先に実行）
 - **#48 画像ホットリンク:** 利用規模が数百人規模になったら `next/image` + ワイルドカード許可を再検討
 - **`@types/node` メジャーアップ保留:** 24 → 25 は影響調査が必要なため今回スキップ
+- **onboarding-scrape の `APP_URL` 環境変数は不要になった**（PR #67 で削除）
 
 ## 参照すべきファイル
 - `CLAUDE.md` - プロジェクトガイド
 - `docs/ARCHITECTURE.md` - アーキテクチャ全体像・ブランチ戦略
 - `docs/DATABASE_DESIGN.md` - DB設計（RPC関数一覧含む）
+- `docs/EDGE_FUNCTIONS.md` - Edge Functions の環境変数・仕様
 - `.nvmrc` - Node.js バージョン指定（24）
 - `package.json` - 各パッケージバージョン
 
 ## コミット履歴（直近）
 ```
+945c20d Merge pull request #67 from mktu/feature/fix-onboarding-liff-url
+449bf52 fix: resultUrl を必須パラメータにして APP_URL フォールバックを削除
+1003a67 fix: use LIFF URL in onboarding result notification to LINE
+86c66a0 docs: update SESSION.md for session handoff
 c4f22a4 Merge pull request #64 from mktu/feature/update-nextjs-core-libs
-8b7a325 chore: update Next.js core packages
-04b5afc docs: update SESSION.md for session handoff
-f20da76 Merge pull request #62 from mktu/feature/update-nodejs-24
-1309382 fix: remove invalid vercel.json
 ```
 
 ## GitHubリポジトリ

--- a/docs/EDGE_FUNCTIONS.md
+++ b/docs/EDGE_FUNCTIONS.md
@@ -129,7 +129,8 @@ Edge Function で使用する環境変数は Supabase Dashboard で設定:
 
 **onboarding-scrape で必要な環境変数（Supabase secrets）:**
 - `LINE_CHANNEL_ACCESS_TOKEN` - LINE push 通知用
-- `APP_URL` - LINE 通知に含める結果ページ URL（例: `https://your-app.vercel.app`）
+
+> LINE 通知のリンク URL（`resultUrl`）は呼び出し元の Next.js API（`/api/onboarding/start`）が LIFF URL として組み立てて渡す。`APP_URL` 環境変数は不要。
 
 > ローカル開発時は `LINE_CHANNEL_ACCESS_TOKEN` が未設定でも警告のみでスクレイピングは継続する。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/google": "^3.0.13",
-        "@line/bot-sdk": "^10.6.0",
-        "@line/liff": "^2.27.3",
+        "@line/bot-sdk": "^10.8.0",
+        "@line/liff": "^2.29.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -1591,464 +1591,484 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@liff/add-to-home-screen": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.27.3.tgz",
-      "integrity": "sha512-phiE+U6XW+Qw48DGn89OITgpUbDyJxfSiTIVB01BTbEIT9mZq4qBSrl1M2OJNO3uJO+JC1zUE81kW1Y4Zh313Q==",
+    "node_modules/@liff/activity": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/activity/-/activity-2.29.0.tgz",
+      "integrity": "sha512-+i+f3twUsKMZf0Zt1Z/IrS7thMvOET8Lj7rLj+X77PD8IVPhxoMP9X6wZ8biJCdZmnPp66XqJNy8Nzs1eK8gVw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/open-window": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/native-bridge": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/add-to-home-screen": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.29.0.tgz",
+      "integrity": "sha512-nMfNakFC0KZCz1fGsSdLc3PaSh87WK0tMiQmpEEKAOxeFpvFFqQM09mgqsPxWUHhW7eczQuTWQTUzliDPwKl2g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.0",
+        "@liff/open-window": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/analytics": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.27.3.tgz",
-      "integrity": "sha512-UQtHSFfnwUm9MJeCUyemz8aT5plSBo0O4qgFoHswqI4j7IIVdKoRSzI0yVyQZoBkaRHYnngPLNbpZYpb9XBYHA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.29.0.tgz",
+      "integrity": "sha512-CXyWeXFnoGuXdjIEQNTgeXkW5D7gsQAUb1pE44tnTLWxmfUmMQMieMcn4LRybw3EitUelNAD7unpTWPf4fFCww==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/core": "2.27.3",
-        "@liff/get-profile": "2.27.3",
-        "@liff/get-version": "2.27.3",
-        "@liff/is-logged-in": "2.27.3",
-        "@liff/logger": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/core": "2.29.0",
+        "@liff/get-profile": "2.29.0",
+        "@liff/get-version": "2.29.0",
+        "@liff/is-logged-in": "2.29.0",
+        "@liff/logger": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/check-availability": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.27.3.tgz",
-      "integrity": "sha512-smgEDErWtaeeInvhba5Qu1qktNA6Lya2BeEUATo+qo/FEAq4EpJg3XdFAEYR3Cy01epPqZErfAamfJ0zbnXJNQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.29.0.tgz",
+      "integrity": "sha512-XZat8Znhm9Pmhz6EFv+6vcqH7EexOcm3M2QY1ngxTUxynWb5ihBmQOb68NB/XxZq9LTqJSBASU/bOCMN+VcsnA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/get-version": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/get-version": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/close-window": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.27.3.tgz",
-      "integrity": "sha512-rD4htQfn3uCnvC4AlWmKQal9W8Q88eL7ATXgOLjpqFTYwC/G3/RyJiPLZt3VlVuLtkE8UsGpCrui12+AJZxjNg==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.29.0.tgz",
+      "integrity": "sha512-0T4G+lXIlvwatVDmy4qAHuMBrLW0fmjxYKUondTtopLMC5YeE6jOoLs8WuFptysqkT0RpmAW9p6oOA0qOf1nxg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/native-bridge": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/native-bridge": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/consts": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.27.3.tgz",
-      "integrity": "sha512-deKrjOANRtOULCJSKm1AoQKK7OEa9Y6PpDhp7kVFtDpwO/DRvZ4OR4un2QaT8jxJKiIGcoGbrOl5FvWtTGun0g==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.29.0.tgz",
+      "integrity": "sha512-ostJMjPTYSadj2sWIATcQGckTAfgyxVQX7v1q68cwABo2qWfTwnh2mmvJ4j7YYRHlkekdMnirdk2SBXrfOlSjA==",
       "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/core": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/core/-/core-2.27.3.tgz",
-      "integrity": "sha512-AwT4P9njx70ikE/Az5UO6QikyVnaS+Le2YAWot/Actru4hR866kMZLIJkVOVP1H8m3M6BuKyRUvqRPhvbZqKMw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/core/-/core-2.29.0.tgz",
+      "integrity": "sha512-YoqFtnTF1ZQo6onMixueSesPuhQ+6Oxxs4deO6r6UTHRNZXK8ykf4dxrF2OBwiBCHLe0dgCnRbK/w5v7ALt1ig==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/get-version": "2.27.3",
-        "@liff/init": "2.27.3",
-        "@liff/native-bridge": "2.27.3",
-        "@liff/ready": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3"
+        "@liff/get-version": "2.29.0",
+        "@liff/init": "2.29.0",
+        "@liff/native-bridge": "2.29.0",
+        "@liff/ready": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/create-shortcut-on-home-screen": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/create-shortcut-on-home-screen/-/create-shortcut-on-home-screen-2.27.3.tgz",
-      "integrity": "sha512-sJDY82VTzG4OdD9NoldZBl1s6X6mG/Z94OIuMFh+N7XuDHymTJidiadJQWYiyJ/9dojkYIkoyZ52+xUtAu6Ajw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/create-shortcut-on-home-screen/-/create-shortcut-on-home-screen-2.29.0.tgz",
+      "integrity": "sha512-Ctky3q12b4otNY2uvvFL5zDZNXXNnbO1bbPgagHVtCdRdayFKb1iy3fI6hWclvQvdoKsOcxfm+gyZlE1G41j1w==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/open-window": "2.27.3",
-        "@liff/permanent-link": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/open-window": "2.29.0",
+        "@liff/permanent-link": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/extensions": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.27.3.tgz",
-      "integrity": "sha512-r6wCMvTS+krTY4/fpf8lKQZnv4Q1WaLEZXbWnvvz2aNrn6HNNGyeldAFDpmOQQWl2ve5iwMdaySt+0T8PlCefQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.29.0.tgz",
+      "integrity": "sha512-RpeCAUHhpSUQ2LbICzFn7WlxgK+s0M5TSbm0opfkn1X+duNTMWhyx/vM92GslVF6o+KwKr83RlrSdfo4051dbA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/add-to-home-screen": "2.27.3",
-        "@liff/check-availability": "2.27.3",
-        "@liff/consts": "2.27.3",
-        "@liff/get-advertising-id": "2.27.3",
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/logger": "2.27.3",
-        "@liff/scan-code": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/add-to-home-screen": "2.29.0",
+        "@liff/check-availability": "2.29.0",
+        "@liff/consts": "2.29.0",
+        "@liff/get-advertising-id": "2.29.0",
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/logger": "2.29.0",
+        "@liff/scan-code": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/util": "2.29.0"
       }
     },
     "node_modules/@liff/get-advertising-id": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.27.3.tgz",
-      "integrity": "sha512-hGtfNykZott9Yy2tEa9Dw8NGgPb0ojWe7YJCU92ZDzTKdXhSXlvKfk21WT82MLfqgQSohWxAZOrdVq3CE7eyQA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.29.0.tgz",
+      "integrity": "sha512-/N9d0YWUC9wHaqZPXR5Z55v9SdbntoxOlXxNOkJH9G7Iiz9hwSws37aGHI2BMh81E+2tLJrpaBX9q+Tx/TNg1g==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/types": "2.27.3"
+        "@liff/types": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-app-language": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-app-language/-/get-app-language-2.27.3.tgz",
-      "integrity": "sha512-GjJALoJP8+h8vdYaxJ7glFKWYFk8iDhnPrx7kbJkBn6SMpvdzJaUUGij7gzhNkzGp0qyxdApCWrRfuHNkcGmjQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-app-language/-/get-app-language-2.29.0.tgz",
+      "integrity": "sha512-31dRa3tkKAZclKNVkXbgIm2ufwnblKbog4W1VcZMb6OPolH44LDWqgXpEy/HJiBM6Z4h3pfwZitl5heaqsgJlg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-friendship": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.27.3.tgz",
-      "integrity": "sha512-GmE+dOiwY6K3d4LDqdkTrUr1IcvjV9XY/eSMZoEWO7HIyC19kKnJFNt0lU5j3tPTs3lu2FHXdrN/cR5zqlCx+w==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.29.0.tgz",
+      "integrity": "sha512-yGeOxMzT9m3EBdvdQjNFHEkXGoiMW8GZ79EAtWKboNlkQ4Q0gQXZH5fBGwx69EgHW7+a1/qi/ocd2dvBSk+NIA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/permission": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/use": "2.27.3"
+        "@liff/permission": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-language": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.27.3.tgz",
-      "integrity": "sha512-9TR3VeaxmwIwe/yRlwQFfFSYwimPRW72YC/z1X2eAY9ZyIWq0knyJUe/dY3aLyP781YG/YCzZ057xaBAzrbyhQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.29.0.tgz",
+      "integrity": "sha512-guFiLc+bgXzklfcRwQejlYqn0sUWmWotx/qEzU0JIsC3Bf/kep4/nxsm+E/UnSkMPm3Bvod4ZFXnKQdmaGRvCA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/use": "2.27.3"
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-line-version": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.27.3.tgz",
-      "integrity": "sha512-ZBvUrGPVL/STZUFOnjTUWGK67IJCdx73XZNTvzob5VRCVb0ruBUwHlLs2IKYyAgT4RnZWzAfjXq6QyNRHwwvfQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.29.0.tgz",
+      "integrity": "sha512-3QwqDh0Yb9A8b2URy/XPuhf7iZhbhxm+SjonbgcN6kI0uHQQ0E+qHTEpOeJo4YS3IOy2PxXP16FMj21zciOa3A==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/use": "2.27.3"
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-origins": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-origins/-/get-origins-2.27.3.tgz",
-      "integrity": "sha512-wrKWQUE4NRxaDxWaSOGUDoW7nLgWuD7OM5c6v+PTC2w27Fmtv4N40ZIV9r7IIHzzxhv2F+pHC+cFU4++383dAw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-origins/-/get-origins-2.29.0.tgz",
+      "integrity": "sha512-e0hcUtWnYgh20wixeHyVC1tHKbvTlqlPGVb3BKRgb6wsMlCOZcZAOuU2KxR3m2yfoNHeEuiWAM5iu4oZN25gaA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/use": "2.27.3"
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-os": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.27.3.tgz",
-      "integrity": "sha512-TgITSkhuKrUUfQIWZ/8BgdA1QFXPsZ9Q97nADOm8dx+cxFDhZB0+bVJfoU+ByPCCm+83/vLs5y9XHuRn/MbQgw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.29.0.tgz",
+      "integrity": "sha512-iF4FfLU+OfQDNCEuBD9xQ5S3ODXJxFJT44JcrQhqxmF9Zb+/sZ6n4H/jqPiFFmqX9miJZsOYULcl04GIwQ9OuA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/use": "2.27.3"
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-profile": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.27.3.tgz",
-      "integrity": "sha512-1Y5cqlGcFxISDcOdIVXOA1AK9xxTq+sTdy/lkUsVKfCqCMtEesoIonc6xueTbOZ9YLODTCKUE501ng/5rwrc0w==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.29.0.tgz",
+      "integrity": "sha512-aIDp9qLwQvPW2OoDXxgkhUi8OzmhkpkY045UxdIq1fK8AAWuIvQjfWgFuC+MAsbnIO29kk80H8DqQSFHYntseQ==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/permission": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/use": "2.27.3"
+        "@liff/permission": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/get-version": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.27.3.tgz",
-      "integrity": "sha512-68E4wI9wAdR+iL3YzDmbog0kksViCbh9OoYo+jv0K1pEV0Tv1cMkk+ohZa04bp2nao+w1PnV/+Pap0zmwgSiDg==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.29.0.tgz",
+      "integrity": "sha512-PVn/hXi0S2JYtBfQpCjF9gUT4uYbPWaPPpDhLbQfzt9GmAc2G5D5nRV0PxLmG5iUj+kml4z2lEyT85qIQibu2w==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/use": "2.27.3"
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/hooks": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.27.3.tgz",
-      "integrity": "sha512-0S0ekQgVcJq5h14ANkg2MOJMBBxSa3vpBqvvEORT6ty47evmcno6rJxmynLk1uoapFRzRNt7V+s53L+X85dWrg==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.29.0.tgz",
+      "integrity": "sha512-lGFfnWGQaFsGYiR5mLkjDxIaA67CgBqy+bHK7YpMlozOn+D3Nh+RqDRLGINFz6+ukf5kGwG99lYMp6qx2CLbAw==",
       "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/i18n": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.27.3.tgz",
-      "integrity": "sha512-FyO+1BURCnEh6Q41oVTWt0FeFpk/VozvJrsP+2rTaYB67pZfDAVKKjJEJUn2lJ6CXd0tUogSJYfoWZMxVtfuNA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.29.0.tgz",
+      "integrity": "sha512-bt52QE+oOg7AdgJeNNlWNRu+buT4UgcQWtFXJxxfvMEiuz12ybwOuzTIict0jxBLBN807+UcBJZ/shh0ZIIe0A==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/iap": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/iap/-/iap-2.27.3.tgz",
-      "integrity": "sha512-Mgn34//cDAA5inLowBOVoCHZSfETUP7Z9OiqVHqrncFlmCbc6UAzsBm6SffimW2R5Y05EHIIhgrapZofD32+uA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/iap/-/iap-2.29.0.tgz",
+      "integrity": "sha512-cnDRQrN9HS59v2hZyRsAAMLoAd2MJJttqg1G2vqVBzScSBeEdktBf63ymMGpYETxOTyz795c3RKOQa8ocybWHg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/native-bridge": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/native-bridge": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/init": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.27.3.tgz",
-      "integrity": "sha512-CfW2JWSMtvOcjPsXfWsPsVB8J9++Eij5qIdY7ePEvWPsmMs0znstzUsDzqJOqlh/bBd1ccPVvFhd0LevRd4M5A==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.29.0.tgz",
+      "integrity": "sha512-qJm2/yU9oHbqPq+o4kkpLrbzE056Ypy7mVjx4YaOjmBYZ8QZ0xiCDwKsIvQ86pjeWH2YU/o4h6wPkF8crA72jQ==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/check-availability": "2.27.3",
-        "@liff/close-window": "2.27.3",
-        "@liff/consts": "2.27.3",
-        "@liff/extensions": "2.27.3",
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/hooks": "2.27.3",
-        "@liff/i18n": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/is-logged-in": "2.27.3",
-        "@liff/is-sub-window": "2.27.3",
-        "@liff/logger": "2.27.3",
-        "@liff/login": "2.27.3",
-        "@liff/logout": "2.27.3",
-        "@liff/message-bus": "2.27.3",
-        "@liff/native-bridge": "2.27.3",
-        "@liff/permanent-link": "2.27.3",
-        "@liff/ready": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/sub-window": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/check-availability": "2.29.0",
+        "@liff/close-window": "2.29.0",
+        "@liff/consts": "2.29.0",
+        "@liff/extensions": "2.29.0",
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/hooks": "2.29.0",
+        "@liff/i18n": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/is-logged-in": "2.29.0",
+        "@liff/is-sub-window": "2.29.0",
+        "@liff/logger": "2.29.0",
+        "@liff/login": "2.29.0",
+        "@liff/logout": "2.29.0",
+        "@liff/message-bus": "2.29.0",
+        "@liff/native-bridge": "2.29.0",
+        "@liff/permanent-link": "2.29.0",
+        "@liff/ready": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/sub-window": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0",
+        "@liff/verify-id-token": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/is-api-available": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.27.3.tgz",
-      "integrity": "sha512-2jdMw621nLX/RJyxYBdIDvtw3qO5QwSco7UUEPAf+RS9AZG1auEbkLPTtlUmc2PVu8jSEe6UyGRlfVRho3wt6g==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.29.0.tgz",
+      "integrity": "sha512-vrcwuDRfW9VYtjy2YNKa9oAawrBOqNm8kQTtU4jPI/i6Q5RqUrCUiJraeJy+ArsEo7RIfs+PSnkoTGr3HTy7Vg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/is-logged-in": "2.27.3",
-        "@liff/is-sub-window": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/is-logged-in": "2.29.0",
+        "@liff/is-sub-window": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/is-in-client": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.27.3.tgz",
-      "integrity": "sha512-gexl4OYrpwFHlChG4Z+EGK4ii7lY+N/ki1LDT7gt3uKTj9TuLHFsI/Z+dGsLJArUEVUOJfehAmsW4xYjpwKTaw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.29.0.tgz",
+      "integrity": "sha512-68zZaDiXrV5aFS70uMqJfw32N3TEjsHy0B1+Bf7SL64QJIiC18Y6WbEOxRmjHQdLtvdV52avzSIJa6aEbl0kLA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/is-logged-in": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.27.3.tgz",
-      "integrity": "sha512-D1/e3hMxSlGVO1jMwgvtNzW01PlFpJuRUlIAnC9Gmlstg8FsQnMYdgCGd0rKBdQTUGPAZPmDu+pgps6pR5V0zA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.29.0.tgz",
+      "integrity": "sha512-XvYee02R2QLS/ulKbYcb+gJmwNyMn/tCduMCsTXRENYayQS3swWD6pBT3pabn9NqDgIeXmvm7PAYpTypnRqo2w==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3"
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/is-sub-window": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.27.3.tgz",
-      "integrity": "sha512-2fUSo+Z6gozqFFW5nIc85GK1EM5mYOwaSRrlqWoEDQGHij/FEen6p+0mGByv5gxGWyMM1rtR3j11ePlCf/GGlQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.29.0.tgz",
+      "integrity": "sha512-jBkdymEPiVKgqIH+ffiD2NMTmkqhHJ7kSOS7c9G9WVwu9nXOHBu5HmWmJmN4ElMeEP7lWQkts57aJFYHWR1PiQ==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/liff-types": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.27.3.tgz",
-      "integrity": "sha512-vEcz1Q62z4awpKCHSOtUZy98AX/3QHThaWi2aXNaAHHqKq1f/SPZLDgcTBHjeP8YyZmJ+qBYpondU8etY4cIJg==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.29.0.tgz",
+      "integrity": "sha512-5+Grc/Ff05pKrwCgC7iRnBrDd218ge0VYp1GRC7shYPk/EONTg0sl+Y2DdA8e9BBzylePNXS8YiySNQiADYnHw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/analytics": "2.27.3",
-        "@liff/close-window": "2.27.3",
-        "@liff/create-shortcut-on-home-screen": "2.27.3",
-        "@liff/get-app-language": "2.27.3",
-        "@liff/get-friendship": "2.27.3",
-        "@liff/get-language": "2.27.3",
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-origins": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/get-profile": "2.27.3",
-        "@liff/get-version": "2.27.3",
-        "@liff/i18n": "2.27.3",
-        "@liff/iap": "2.27.3",
-        "@liff/init": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/is-logged-in": "2.27.3",
-        "@liff/is-sub-window": "2.27.3",
-        "@liff/login": "2.27.3",
-        "@liff/logout": "2.27.3",
-        "@liff/native-bridge": "2.27.3",
-        "@liff/open-window": "2.27.3",
-        "@liff/permanent-link": "2.27.3",
-        "@liff/permission": "2.27.3",
-        "@liff/ready": "2.27.3",
-        "@liff/scan-code-v2": "2.27.3",
-        "@liff/send-messages": "2.27.3",
-        "@liff/share-target-picker": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/sub-window": "2.27.3",
-        "@liff/use": "2.27.3"
+        "@liff/activity": "2.29.0",
+        "@liff/analytics": "2.29.0",
+        "@liff/close-window": "2.29.0",
+        "@liff/create-shortcut-on-home-screen": "2.29.0",
+        "@liff/get-app-language": "2.29.0",
+        "@liff/get-friendship": "2.29.0",
+        "@liff/get-language": "2.29.0",
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-origins": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/get-profile": "2.29.0",
+        "@liff/get-version": "2.29.0",
+        "@liff/i18n": "2.29.0",
+        "@liff/iap": "2.29.0",
+        "@liff/init": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/is-logged-in": "2.29.0",
+        "@liff/is-sub-window": "2.29.0",
+        "@liff/login": "2.29.0",
+        "@liff/logout": "2.29.0",
+        "@liff/native-bridge": "2.29.0",
+        "@liff/open-window": "2.29.0",
+        "@liff/permanent-link": "2.29.0",
+        "@liff/permission": "2.29.0",
+        "@liff/ready": "2.29.0",
+        "@liff/request-friendship": "2.29.0",
+        "@liff/scan-code-v2": "2.29.0",
+        "@liff/send-messages": "2.29.0",
+        "@liff/share-target-picker": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/sub-window": "2.29.0",
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/logger": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.27.3.tgz",
-      "integrity": "sha512-y9efMeuty1hz0W5j1sxgNnaDJxKZgUUdNXEl7MMdaKkIAvmeC8WyFhAnrDWzDlNmsaRKyurVhdPZNswyAIS6ig==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.29.0.tgz",
+      "integrity": "sha512-d+T9N9TreTJSTtLBGKFvoVNL2Rk6nb/+xDEbZbJ5y9A/ou0VucZ+NcRsAvv8BiMN+xVWoMFp8I5Bp/elh/HZjQ==",
       "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/login": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.27.3.tgz",
-      "integrity": "sha512-XnPZiCIKA8KUp8tC43qOhaNhI0XrRBpIuHQ6Rs1zxBr07XBbfWFMBBqk1YQ+e2UgxdV/U8DIgboV7AgLdfexKw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.29.0.tgz",
+      "integrity": "sha512-MsGRTkdmSn0TrUxwPojYx3dvDPmY5UaiUxE5uIkufycPooM8D3W44DkJpmrNCs8c3PzG4tPaF55/SGpdZYXX8g==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/get-version": "2.27.3",
-        "@liff/hooks": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/is-sub-window": "2.27.3",
-        "@liff/logger": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/sub-window": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3",
+        "@liff/consts": "2.29.0",
+        "@liff/get-version": "2.29.0",
+        "@liff/hooks": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/is-sub-window": "2.29.0",
+        "@liff/logger": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/sub-window": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0",
         "tiny-sha256": "^1.0.2"
       },
       "peerDependencies": {
@@ -2056,152 +2076,171 @@
       }
     },
     "node_modules/@liff/logout": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.27.3.tgz",
-      "integrity": "sha512-L/4V5ncv1oAkWETsKSxjVgkodKjFjd7tdUTf/vv9yWXIqSWcFpNVyxJa9CXrpTHMQBLi0gQinbk40UouBWaR2Q==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.29.0.tgz",
+      "integrity": "sha512-BGRKV2Ms2uG5kGg0kSUj7qKM6t99KwLX/+AsTeRa8dJCn92SlxKmK4LDsyuNUb7fRhz5LmeF88grV4Tt7QKcwA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3"
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/message-bus": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.27.3.tgz",
-      "integrity": "sha512-cGaFE58pbUHucTrHTkhtMBIYvh60/lsKzseWuSFG22+XXiivrtxXHU4SSAjIMdwVQ9eRwFaHWUeVDa5btikWkw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.29.0.tgz",
+      "integrity": "sha512-Mj93yOkSdslxmVr94SZWS8+4P3VOF045AafY9Tuj18U2jDhUAj04/tKR0qw4BMBBsXR7mKnVO907m5p2Lmzn5A==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/native-bridge": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.27.3.tgz",
-      "integrity": "sha512-7i+pfdhjew1y3fhnmELJRUt8SGZc89Kotfyq+dKvGeCSLRfKi9l2TLab/YTE63jL8CMY2zHZMfOAyCjTirROAw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.29.0.tgz",
+      "integrity": "sha512-lvCaMDwaA8NFe3/8GrowASsD4205vu77YV59qo+FnETEPG92jqHXl+qodrA983kI4iMUCKtsqDcYEH2zqiRf/g==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/logger": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/logger": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/open-window": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.27.3.tgz",
-      "integrity": "sha512-2AKs8ClYoU4xqMDKorl7YMplQa7ThadM5B60d8XrzCOdDi2Tbu0K4shfy4+kE5aOfWc0/YTrHfl5Kc9Fy2IlFg==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.29.0.tgz",
+      "integrity": "sha512-95ZysFJDqyIhchkXABXE6SbMcdIGSMd2EYkg2K0uYbpRyszxC96Hg/l6jWTEb9UQXn+J2PzZMFgBdFtzGNInmw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/native-bridge": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/native-bridge": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/permanent-link": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.27.3.tgz",
-      "integrity": "sha512-awy6I6qlUnE54Sb/mZs0ExUjSPm2E+v863GvkN6FTXUvFq7o6M56Ozwvp7Z8tTrHlwIW7J/UUQD13xEIE83t7w==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.29.0.tgz",
+      "integrity": "sha512-+/V3sNhxgZOBPJ5EPMBxerQM714aumk4V1hg71TIVLuzpySCNbvHz90cS6EMgfGPJWwgjWE/H8tGwtOo0fF5pA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/permission": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.27.3.tgz",
-      "integrity": "sha512-C+nf3TdAB5/iViEWhyZYJH1vVTmq+gS+gP835pHOgMt1nxHRG2nZyUltwCShPnj9XWM1NC5njFCpMrwdoRL24g==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.29.0.tgz",
+      "integrity": "sha512-ev8Z+QnJFR6ZTNw7pNNlW75js8Q3GXlTAWktaxr7HtCKTaLy//mBptZWVg/p+6LHZxLrT96dbLnUA07lHj3UbQ==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/sub-window": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/sub-window": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0",
+        "@liff/verify-id-token": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/ready": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.27.3.tgz",
-      "integrity": "sha512-WoY98zRuUeuyvQIMS3lsGAtsAXQNRdi+mVL0zPO60vGxV10ezRDfRVJY0tJAO7fSSUjbgjDgRVhpzfsSi8aPvA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.29.0.tgz",
+      "integrity": "sha512-mJzLmxRctoq3h65EXE0FbW/qBdJM5+9iAJPFQ1kEQe+Yu1g4ucMAAtZBG6lnstMQnHJ48VerIPPwViGIyewwDw==",
       "license": "SEE LICENSE IN README.md",
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
-    "node_modules/@liff/scan-code": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.27.3.tgz",
-      "integrity": "sha512-DM0/Z95e9sgauJjyPzAqTQGOwMXSV0O1LcxnijNSalNdKo1GjJ2qPhNuFjiYJHnU3iqR9fXiw7+uCQAZpULnRw==",
+    "node_modules/@liff/request-friendship": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/request-friendship/-/request-friendship-2.29.0.tgz",
+      "integrity": "sha512-WMBy8dMMTBUj6M1opxMzA6YWbWThb73/BXxTAHx2hNfvl+0WIx1todNPJ1+F1/d/lkFMETuWQx2jJO3pI4RAsQ==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/types": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/sub-window": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/scan-code": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.29.0.tgz",
+      "integrity": "sha512-a+AckJPTHWZ++yV6JM9V4oi0eM2UfmLe1HmFEh1DZ0V5CdUNT2TsDGppAmkIElvTUUirWh9vHXpuWOtQbumOWg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/types": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/scan-code-v2": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.27.3.tgz",
-      "integrity": "sha512-Dy7HMmtS6XGiwhCpTdLPeBQrPNxuVv3lJlQ6NHq60FiYHyybuTLaRhXEq77jww2+Dru3M/dZWoH1L4+rQ+B0WA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.29.0.tgz",
+      "integrity": "sha512-OQBVnN0cJcddNXIPx0qBjDbYQlx2FVuS8p2zuaqxjdJQm9DzZ/otPtBA1Fu8OLJFoh+orPAVrigWPf4898YaGg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/sub-window": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/sub-window": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/send-messages": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.27.3.tgz",
-      "integrity": "sha512-rhda9rRh0DttqQ1bEChTn6kHe1rYSCPHfawPFgPFQH47LqSoA43kDkFItZeHi2NeDeZE/HBwf+7Eqq47ccqqHQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.29.0.tgz",
+      "integrity": "sha512-NI/++qlkvs04bwulPbADFmqUILKg1AnuN+6NuOi+suMejhEEJkJI/wlw/FWljEEI0V6fzGNZFsOcsAxdxaAKXg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/permission": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3",
+        "@liff/consts": "2.29.0",
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/permission": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0",
         "@line/bot-sdk": "^10.0.0"
       },
       "peerDependencies": {
@@ -2209,135 +2248,149 @@
       }
     },
     "node_modules/@liff/server-api": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.27.3.tgz",
-      "integrity": "sha512-9vVnxl4vmDfkKmyp4FLiZDSjG3KLiVUOLpy8AS/9+vXsChPyPEqB4gGf+a0AjY+8p2snIQiOzaLZeNuiD2sBbw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.29.0.tgz",
+      "integrity": "sha512-mg6zbm7wJVUExYzbLwmkkkRQF50T3N+RHY6MOFtYIX7WgV5gkz4ZpLIbbu1oc7F4MWFNW1npe6rEXEp2jxO/5A==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/share-target-picker": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.27.3.tgz",
-      "integrity": "sha512-0bJDh7OQBPy0/ZAOxvev6ZvW07OjhjrA8e1JasCbhupFAndxdIQuruUoKZjderyQmrJ9LjauuOwN4LbgowMe3Q==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.29.0.tgz",
+      "integrity": "sha512-6RoP5i56/Rt+B2Q2n0IAiz5eN/BThPrWJzl5irt+m3mpnhj6V0f+gxah6rzz/U0oIV97ozcQBI20tVBaakqhNQ==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/analytics": "2.27.3",
-        "@liff/consts": "2.27.3",
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/is-logged-in": "2.27.3",
-        "@liff/is-sub-window": "2.27.3",
-        "@liff/logger": "2.27.3",
-        "@liff/send-messages": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3",
-        "@liff/window-postmessage": "2.27.3"
+        "@liff/analytics": "2.29.0",
+        "@liff/consts": "2.29.0",
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/is-logged-in": "2.29.0",
+        "@liff/is-sub-window": "2.29.0",
+        "@liff/logger": "2.29.0",
+        "@liff/send-messages": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0",
+        "@liff/window-postmessage": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/store": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.27.3.tgz",
-      "integrity": "sha512-KnfOVeKa3Ztu4QYy78bzD+BRpmUm/XaHftTmPJpRvTHCgqiZadZiVKvrPjkt4wRgs0JxzCO27iki55xMGC1fWw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.29.0.tgz",
+      "integrity": "sha512-zT4WfpmDc+67pKeqWwdpScV7pbshfb6DqolpFn/T0nEOj1i87T4+7CNk/1zYPwsTY5Lqb88o0zJV1nZXxIlUrg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/types": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/types": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/sub-window": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.27.3.tgz",
-      "integrity": "sha512-BS3ikYWt3IZxhZhby+dvDIjFDalr9iE6gdETLUxu2CdUqBAAyu1qE2ivNpEtniYjDOd3nzoHbs83Ca1G12lD8g==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.29.0.tgz",
+      "integrity": "sha512-CSjNQjIG/oRwipruQgVQmWr7WrC7ZazZUbPqzp8SMbstDiynR1OdHfPbf0aZFZ9q6o6EuBrGiYGQOnytonC9og==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/close-window": "2.27.3",
-        "@liff/consts": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/is-sub-window": "2.27.3",
-        "@liff/logger": "2.27.3",
-        "@liff/message-bus": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/close-window": "2.29.0",
+        "@liff/consts": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/is-sub-window": "2.29.0",
+        "@liff/logger": "2.29.0",
+        "@liff/message-bus": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/types": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.27.3.tgz",
-      "integrity": "sha512-yLv24DK8jwt97/xsWlHu4V8uihfQS44c45GhoYaHKz65zwk8U+bungIzgg4N1Vy4fIYsrR5UBw5CdIyM7L+lLQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.29.0.tgz",
+      "integrity": "sha512-r6knQt/DPvkZO5oxPP858lZbD+dhKGm5osqkDckL8dzxkIal5amY9PSXX4dD5JuFv9dsJgL4af9KfIZl/ZOFYQ==",
       "license": "SEE LICENSE IN README.md"
     },
     "node_modules/@liff/use": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.27.3.tgz",
-      "integrity": "sha512-iDyfaM5O2LDx5BoDK2+jvlwZsrXMcZyeRzsxX8jo5VmlC1Ngs/ox2XwnYcqjIFelJ1Mfx2ACA6Sgm9FO2QmMtw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.29.0.tgz",
+      "integrity": "sha512-KSW52LHSJ8GWdd+Jtmpk8s4+9DqxL7eSg27a79bynJsRsaY2SXVvp4v2WcBBl8QX/L8iDL8/EeEJ22eSbp4Ehw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/hooks": "2.27.3",
-        "@liff/logger": "2.27.3"
+        "@liff/hooks": "2.29.0",
+        "@liff/logger": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/util": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.27.3.tgz",
-      "integrity": "sha512-8rIzm8t9CIwW8xjzOF0ALF4xc0q4izdTsh6AgTKIGyfpF1yq7vTumTs67s5hxF64v9BWUC2ggDe7cMIoF50DdA==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.29.0.tgz",
+      "integrity": "sha512-BsRLivSgg2sLmbN9uO5z2KjiFK4FhqBNgAjsVP6hs5p/1DRNOPczmp11Vija6MTQ9JL0cs1CY6xBaHzKDa9Ntg==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/logger": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/logger": "2.29.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/verify-id-token": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/verify-id-token/-/verify-id-token-2.29.0.tgz",
+      "integrity": "sha512-EDj9Uxt1qTuH2TZ25+dEKPxTu4K+MpKjpUIV1qTLWqnQQd4VqpJ4bkgDnbxfwKkp0rSWV093GMyZF/pG6x7fMQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@liff/window-postmessage": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.27.3.tgz",
-      "integrity": "sha512-rVQTBIROL3DMWpjzC2/f5qYO2mAZsV+1Rk4NVJzUpB59atEddmXONLGPlSk3GFASLMcU8Sb3G8gu61dFrM9wNw==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.29.0.tgz",
+      "integrity": "sha512-rIsGf3xC/3JAb/1Nyoqrcss5UUUECz7v36MhruGeaVvTfzXqz1sviaUnU+rNHxij9CJEqMpA1C8+YDKenF6wMw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/consts": "2.27.3",
-        "@liff/logger": "2.27.3",
-        "@liff/util": "2.27.3"
+        "@liff/consts": "2.29.0",
+        "@liff/logger": "2.29.0",
+        "@liff/util": "2.29.0"
       },
       "peerDependencies": {
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@line/bot-sdk": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-10.6.0.tgz",
-      "integrity": "sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-10.8.0.tgz",
+      "integrity": "sha512-1Mdpw/WPS3QP6fGiwPRTL27k8MgmMe7rVKCKsItP/kPzogX7a/X1ipQqk/F6RkorP9DNyJIx590hnVUkfBQf3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^24.0.0"
@@ -2350,49 +2403,51 @@
       }
     },
     "node_modules/@line/liff": {
-      "version": "2.27.3",
-      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.27.3.tgz",
-      "integrity": "sha512-ot82Rqn0WpMICTDpyVFvmbC18y5N9OTrnDPZLv6lEGvGdjLEMWAlRzBYtZRz61gdsEByTgAPXHULq7V0SMxbNQ==",
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.29.0.tgz",
+      "integrity": "sha512-50xZ7D5FiOM/42d00GEZh2TJ9bHDkbml+5yjUceC5xF19jYQVMrGn70Qbc0GYkVmnZtKp2q9hXQEzk25/arGrA==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
-        "@liff/analytics": "2.27.3",
-        "@liff/close-window": "2.27.3",
-        "@liff/consts": "2.27.3",
-        "@liff/core": "2.27.3",
-        "@liff/create-shortcut-on-home-screen": "2.27.3",
-        "@liff/extensions": "2.27.3",
-        "@liff/get-app-language": "2.27.3",
-        "@liff/get-friendship": "2.27.3",
-        "@liff/get-language": "2.27.3",
-        "@liff/get-line-version": "2.27.3",
-        "@liff/get-origins": "2.27.3",
-        "@liff/get-os": "2.27.3",
-        "@liff/get-profile": "2.27.3",
-        "@liff/get-version": "2.27.3",
-        "@liff/hooks": "2.27.3",
-        "@liff/i18n": "2.27.3",
-        "@liff/iap": "2.27.3",
-        "@liff/init": "2.27.3",
-        "@liff/is-api-available": "2.27.3",
-        "@liff/is-in-client": "2.27.3",
-        "@liff/is-logged-in": "2.27.3",
-        "@liff/is-sub-window": "2.27.3",
-        "@liff/liff-types": "2.27.3",
-        "@liff/login": "2.27.3",
-        "@liff/logout": "2.27.3",
-        "@liff/native-bridge": "2.27.3",
-        "@liff/open-window": "2.27.3",
-        "@liff/permanent-link": "2.27.3",
-        "@liff/permission": "2.27.3",
-        "@liff/ready": "2.27.3",
-        "@liff/scan-code-v2": "2.27.3",
-        "@liff/send-messages": "2.27.3",
-        "@liff/server-api": "2.27.3",
-        "@liff/share-target-picker": "2.27.3",
-        "@liff/store": "2.27.3",
-        "@liff/sub-window": "2.27.3",
-        "@liff/use": "2.27.3",
-        "@liff/util": "2.27.3",
+        "@liff/activity": "2.29.0",
+        "@liff/analytics": "2.29.0",
+        "@liff/close-window": "2.29.0",
+        "@liff/consts": "2.29.0",
+        "@liff/core": "2.29.0",
+        "@liff/create-shortcut-on-home-screen": "2.29.0",
+        "@liff/extensions": "2.29.0",
+        "@liff/get-app-language": "2.29.0",
+        "@liff/get-friendship": "2.29.0",
+        "@liff/get-language": "2.29.0",
+        "@liff/get-line-version": "2.29.0",
+        "@liff/get-origins": "2.29.0",
+        "@liff/get-os": "2.29.0",
+        "@liff/get-profile": "2.29.0",
+        "@liff/get-version": "2.29.0",
+        "@liff/hooks": "2.29.0",
+        "@liff/i18n": "2.29.0",
+        "@liff/iap": "2.29.0",
+        "@liff/init": "2.29.0",
+        "@liff/is-api-available": "2.29.0",
+        "@liff/is-in-client": "2.29.0",
+        "@liff/is-logged-in": "2.29.0",
+        "@liff/is-sub-window": "2.29.0",
+        "@liff/liff-types": "2.29.0",
+        "@liff/login": "2.29.0",
+        "@liff/logout": "2.29.0",
+        "@liff/native-bridge": "2.29.0",
+        "@liff/open-window": "2.29.0",
+        "@liff/permanent-link": "2.29.0",
+        "@liff/permission": "2.29.0",
+        "@liff/ready": "2.29.0",
+        "@liff/request-friendship": "2.29.0",
+        "@liff/scan-code-v2": "2.29.0",
+        "@liff/send-messages": "2.29.0",
+        "@liff/server-api": "2.29.0",
+        "@liff/share-target-picker": "2.29.0",
+        "@liff/store": "2.29.0",
+        "@liff/sub-window": "2.29.0",
+        "@liff/use": "2.29.0",
+        "@liff/util": "2.29.0",
         "tslib": "^2.3.0",
         "whatwg-fetch": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.13",
-    "@line/bot-sdk": "^10.6.0",
-    "@line/liff": "^2.27.3",
+    "@line/bot-sdk": "^10.8.0",
+    "@line/liff": "^2.29.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## 更新内容

| パッケージ | Before | After | 種別 |
|-----------|--------|-------|------|
| `@line/liff` | 2.27.3 | 2.29.0 | minor |
| `@line/bot-sdk` | 10.6.0 | 10.8.0 | minor |

## Breaking changes

なし（`@line/bot-sdk` v11.0.0 で `Client`/`OAuth` が削除される予定だが、今回は v10.8.0 止まりのため影響なし）

## 変更詳細

### @line/liff 2.29.0
- v2.28.0: `liff.requestFriendship()` メソッド追加
- v2.29.0: 内部動作の変更のみ

### @line/bot-sdk 10.8.0
- v10.7.0: `ChannelAccessTokenClient` のラッパーメソッド追加・バグ修正
- v10.8.0: `LineBotClient` 統合ラッパー追加、`Client`/`OAuth` を deprecated に

## 今後の予定
- `@line/bot-sdk` v11.0.0 への移行は別 Issue で対応（`Client`/`OAuth` からの移行作業が必要）

## Test plan
- [x] `npm run lint` 通過
- [x] `npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)