### PR TITLE
chore: update @supabase/supabase-js 2.90.1 → 2.105.4

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,12 +1,16 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-05-17 (Issue #61 オンボーディング「確認中」固まる不具合を修正)
+2026-05-17 (LINE SDK パッケージ更新 PR #69)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **本番稼働中**
 
 ## 直近の完了タスク
+- [x] **LINE SDK パッケージ更新（PR #69）**
+  - `@line/liff`: 2.27.3 → 2.29.0
+  - `@line/bot-sdk`: 10.6.0 → 10.8.0（`Client`/`OAuth` が deprecated に。v11.0.0 への移行は今後別途対応）
+  - develop にマージ済み
 - [x] **#61 オンボーディング結果が「確認中」のまま固まる不具合修正（PR #67）**
   - 根本原因: Edge Function が LINE 通知に直接 URL を使っていたため LIFF 認証が失敗
   - 修正: `/api/onboarding/start` で LIFF URL を組み立てて Edge Function に渡すよう変更
@@ -22,12 +26,13 @@
 なし
 
 ## 次にやること（GitHub Issues で管理）
-- [ ] **develop → main PR を作成して本番リリース**（#61 修正、Next.js 更新、Node.js v24 を本番反映）
+- [ ] **develop → main PR を作成して本番リリース**（#61 修正、Next.js 更新、Node.js v24、LINE SDK 更新を本番反映）
 - [ ] **Vercel Dashboard で Node.js バージョンを 24.x に設定**（手動作業）
   - Settings → Build & Development Settings → Node.js Version → 24.x
+- [ ] **`@line/bot-sdk` v11.0.0 への移行**（`Client`/`OAuth` → `LineBotClient` への移行作業が必要）
 - [ ] **パッケージアップデートの継続**（スキップした項目）
   - `@types/node`: 24 → 25（major、影響調査が必要）
-  - G2〜G7 グループのパッケージ
+  - G2〜G4, G6〜G7 グループのパッケージ
 - [ ] **#45: Vercel Analytics / Speed Insights の導入**
 - [ ] **#37〜#39: E2E テスト**
 
@@ -50,6 +55,7 @@
 - **#48 画像ホットリンク:** 利用規模が数百人規模になったら `next/image` + ワイルドカード許可を再検討
 - **`@types/node` メジャーアップ保留:** 24 → 25 は影響調査が必要なため今回スキップ
 - **onboarding-scrape の `APP_URL` 環境変数は不要になった**（PR #67 で削除）
+- **`@line/bot-sdk` v11.0.0 の破壊的変更:** `Client`/`OAuth` クラスが削除される。移行時は `LineBotClient` を使用すること
 
 ## 参照すべきファイル
 - `CLAUDE.md` - プロジェクトガイド
@@ -61,11 +67,11 @@
 
 ## コミット履歴（直近）
 ```
+8cd434b Merge pull request #69 from mktu/feature/update-line-sdk-libs
+ed8a832 chore: update LINE SDK packages (@line/liff 2.29.0, @line/bot-sdk 10.8.0)
+180274a docs: update SESSION.md for session handoff
 945c20d Merge pull request #67 from mktu/feature/fix-onboarding-liff-url
 449bf52 fix: resultUrl を必須パラメータにして APP_URL フォールバックを削除
-1003a67 fix: use LIFF URL in onboarding result notification to LINE
-86c66a0 docs: update SESSION.md for session handoff
-c4f22a4 Merge pull request #64 from mktu/feature/update-nextjs-core-libs
 ```
 
 ## GitHubリポジトリ

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
-        "@supabase/supabase-js": "^2.90.1",
+        "@supabase/supabase-js": "^2.105.4",
         "ai": "^6.0.48",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -4746,9 +4746,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.90.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.90.1.tgz",
-      "integrity": "sha512-vxb66dgo6h3yyPbR06735Ps+dK3hj0JwS8w9fdQPVZQmocSTlKUW5MfxSy99mN0XqCCuLMQ3jCEiIIUU23e9ng==",
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.4.tgz",
+      "integrity": "sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -4758,9 +4758,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.90.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.90.1.tgz",
-      "integrity": "sha512-x9mV9dF1Lam9qL3zlpP6mSM5C9iqMPtF5B/tU1Jj/F0ufX5mjDf9ghVBaErVxmrQJRL4+iMKWKY2GnODkpS8tw==",
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.4.tgz",
+      "integrity": "sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -4769,10 +4769,16 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.90.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.90.1.tgz",
-      "integrity": "sha512-jh6vqzaYzoFn3raaC0hcFt9h+Bt+uxNRBSdc7PfToQeRGk7PDPoweHsbdiPWREtDVTGKfu+PyPW9e2jbK+BCgQ==",
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.4.tgz",
+      "integrity": "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -4782,24 +4788,22 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.90.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.90.1.tgz",
-      "integrity": "sha512-PWbnEMkcQRuor8jhObp4+Snufkq8C6fBp+MchVp2qBPY1NXk/c3Iv3YyiFYVzo0Dzuw4nAlT4+ahuPggy4r32w==",
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.4.tgz",
+      "integrity": "sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "tslib": "2.8.1",
-        "ws": "^8.18.2"
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.90.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.90.1.tgz",
-      "integrity": "sha512-GHY+Ps/K/RBfRj7kwx+iVf2HIdqOS43rM2iDOIDpapyUnGA9CCBFzFV/XvfzznGykd//z2dkGZhlZZprsVFqGg==",
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.4.tgz",
+      "integrity": "sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -4810,16 +4814,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.90.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.90.1.tgz",
-      "integrity": "sha512-U8KaKGLUgTIFHtwEW1dgw1gK7XrdpvvYo7nzzqPx721GqPe8WZbAiLh/hmyKLGBYQ/mmQNr20vU9tWSDZpii3w==",
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.4.tgz",
+      "integrity": "sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.90.1",
-        "@supabase/functions-js": "2.90.1",
-        "@supabase/postgrest-js": "2.90.1",
-        "@supabase/realtime-js": "2.90.1",
-        "@supabase/storage-js": "2.90.1"
+        "@supabase/auth-js": "2.105.4",
+        "@supabase/functions-js": "2.105.4",
+        "@supabase/postgrest-js": "2.105.4",
+        "@supabase/realtime-js": "2.105.4",
+        "@supabase/storage-js": "2.105.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -5164,12 +5168,6 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
-      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -5188,15 +5186,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -11708,27 +11697,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
-    "@supabase/supabase-js": "^2.90.1",
+    "@supabase/supabase-js": "^2.105.4",
     "ai": "^6.0.48",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## 更新内容

| パッケージ | Before | After | 種別 |
|-----------|--------|-------|------|
| `@supabase/supabase-js` | 2.90.1 | 2.105.4 | minor |

## Breaking changes

なし（後方互換）

## 主な変更点

- Passkey/WebAuthn サポート追加（v2.105.0）
- 一時エラーの自動リトライ（v2.102.0）
- `stripNulls` メソッド追加（v2.103.0）
- Realtime: Phoenix ネイティブ JS ライブラリへ移行（v2.100.0）

## 確認事項

- [x] `npm run lint` パス
- [x] `npm run build` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)