### PR TITLE
feat: オンボーディング結果画面に「全て外す」ボタンを追加

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,24 +1,25 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-05-18 (@supabase/supabase-js 2.105.4 更新 PR #71)
+2026-05-21 (@line/bot-sdk 11.0.0 更新 PR #73 マージ済み)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **本番稼働中**
 
 ## 直近の完了タスク
+- [x] **@line/bot-sdk 更新（PR #73）**
+  - 10.8.0 → 11.0.0（MAJOR）
+  - レガシー `Client`/`OAuth` 削除に伴い `WebhookEvent` → `webhook.Event`、`TextEventMessage` → `webhook.TextMessageContent` に型を移行
+  - `update-packages` スキルの Phase 4 フォーマット改善も同梱
+  - develop にマージ済み
 - [x] **@supabase/supabase-js 更新（PR #71）**
   - 2.90.1 → 2.105.4（minor、Breaking changes なし）
   - develop にマージ済み
 - [x] **LINE SDK パッケージ更新（PR #69）**
   - `@line/liff`: 2.27.3 → 2.29.0
-  - `@line/bot-sdk`: 10.6.0 → 10.8.0（`Client`/`OAuth` が deprecated に。v11.0.0 への移行は今後別途対応）
+  - `@line/bot-sdk`: 10.6.0 → 10.8.0（deprecated 化リリース）
   - develop にマージ済み
 - [x] **#61 オンボーディング結果が「確認中」のまま固まる不具合修正（PR #67）**
-  - 根本原因: Edge Function が LINE 通知に直接 URL を使っていたため LIFF 認証が失敗
-  - 修正: `/api/onboarding/start` で LIFF URL を組み立てて Edge Function に渡すよう変更
-  - `onboarding-scrape` の `resultUrl` を必須パラメータ化・`APP_URL` フォールバック削除
-  - `docs/EDGE_FUNCTIONS.md` のドキュメントも更新済み
   - develop にマージ済み
 - [x] **Next.js コアパッケージ更新（PR #64）**
   - develop にマージ済み
@@ -29,11 +30,11 @@
 なし
 
 ## 次にやること（GitHub Issues で管理）
-- [ ] **develop → main PR を作成して本番リリース**（#61 修正、Next.js 更新、Node.js v24、LINE SDK 更新、Supabase JS 更新を本番反映）
+- [ ] **develop → main PR を作成して本番リリース**（#61 修正、Next.js 更新、Node.js v24、LINE SDK 更新、Supabase JS 更新、@line/bot-sdk v11 更新を本番反映）
 - [ ] **Vercel Dashboard で Node.js バージョンを 24.x に設定**（手動作業）
   - Settings → Build & Development Settings → Node.js Version → 24.x
-- [ ] **`@line/bot-sdk` v11.0.0 への移行**（`Client`/`OAuth` → `LineBotClient` への移行作業が必要）
 - [ ] **パッケージアップデートの継続**（スキップした項目）
+  - `@supabase/supabase-js`: 2.106.0（patch）
   - `@types/node`: 24 → 25（major、影響調査が必要）
   - G3: AI SDK（`ai` 6.0.48→6.0.184、`@ai-sdk/google` 3.0.13→3.0.75）
   - G4: UI / スタイリング（`lucide-react` major あり要注意）
@@ -61,7 +62,6 @@
 - **#48 画像ホットリンク:** 利用規模が数百人規模になったら `next/image` + ワイルドカード許可を再検討
 - **`@types/node` メジャーアップ保留:** 24 → 25 は影響調査が必要なため今回スキップ
 - **onboarding-scrape の `APP_URL` 環境変数は不要になった**（PR #67 で削除）
-- **`@line/bot-sdk` v11.0.0 の破壊的変更:** `Client`/`OAuth` クラスが削除される。移行時は `LineBotClient` を使用すること
 
 ## 参照すべきファイル
 - `CLAUDE.md` - プロジェクトガイド
@@ -70,14 +70,15 @@
 - `docs/EDGE_FUNCTIONS.md` - Edge Functions の環境変数・仕様
 - `.nvmrc` - Node.js バージョン指定（24）
 - `package.json` - 各パッケージバージョン
+- `.claude/skills/update-packages/SKILL.md` - パッケージ更新スキル（Phase 4 改善済み）
 
 ## コミット履歴（直近）
 ```
+b74fb2e Merge pull request #73 from mktu/feature/update-line-sdk-v11
+5dda649 docs: improve update-packages skill Phase 4 process
+8bd719f chore: update @line/bot-sdk 10.8.0 → 11.0.0
+d227500 docs: update SESSION.md for session handoff
 d749643 Merge pull request #71 from mktu/feature/update-supabase-libs
-8d079e6 chore: update @supabase/supabase-js 2.90.1 → 2.105.4
-bb02559 docs: update SESSION.md for session handoff
-8cd434b Merge pull request #69 from mktu/feature/update-line-sdk-libs
-ed8a832 chore: update LINE SDK packages (@line/liff 2.29.0, @line/bot-sdk 10.8.0)
 ```
 
 ## GitHubリポジトリ

--- a/src/components/features/onboarding/recipe-candidates.tsx
+++ b/src/components/features/onboarding/recipe-candidates.tsx
@@ -111,6 +111,8 @@ function CandidatesView({ candidates, submitMode, onRegister, onSkip }: Candidat
   const [customSelected, setCustomSelected] = useState<Set<string> | null>(null)
   const selected = customSelected ?? new Set(candidates.map((c) => c.url))
   const submitting = submitMode !== 'idle'
+  const allSelected = selected.size === candidates.length
+  const masterChecked = allSelected ? true : selected.size > 0 ? 'indeterminate' : false
 
   function toggleCandidate(url: string) {
     const next = new Set(selected)
@@ -118,16 +120,20 @@ function CandidatesView({ candidates, submitMode, onRegister, onSkip }: Candidat
     setCustomSelected(next)
   }
 
+  function toggleAll() {
+    setCustomSelected(allSelected ? new Set() : new Set(candidates.map((c) => c.url)))
+  }
+
   return (
     <div className="flex min-h-screen flex-col p-4">
-      <div className="mb-4 flex items-start justify-between">
-        <div className="space-y-1">
-          <h1 className="text-lg font-bold">レシピ候補</h1>
-          <p className="text-sm text-muted-foreground">登録するレシピを選んでください</p>
+      <div className="mb-4 space-y-1">
+        <h1 className="text-lg font-bold">レシピ候補</h1>
+        <div className="flex items-center gap-2">
+          <Checkbox id="select-all" checked={masterChecked} onCheckedChange={toggleAll} disabled={submitting} />
+          <label htmlFor="select-all" className="cursor-pointer text-sm text-muted-foreground">
+            {allSelected ? '全て選択中' : selected.size > 0 ? `${selected.size}件選択中` : '選択なし'}
+          </label>
         </div>
-        <Button variant="ghost" size="sm" onClick={() => setCustomSelected(new Set())} disabled={submitting || selected.size === 0}>
-          全て外す
-        </Button>
       </div>
       <div className="flex-1 space-y-3">
         {candidates.map((c) => (

--- a/src/components/features/onboarding/recipe-candidates.tsx
+++ b/src/components/features/onboarding/recipe-candidates.tsx
@@ -120,9 +120,14 @@ function CandidatesView({ candidates, submitMode, onRegister, onSkip }: Candidat
 
   return (
     <div className="flex min-h-screen flex-col p-4">
-      <div className="mb-4 space-y-1">
-        <h1 className="text-lg font-bold">レシピ候補</h1>
-        <p className="text-sm text-muted-foreground">登録するレシピを選んでください</p>
+      <div className="mb-4 flex items-start justify-between">
+        <div className="space-y-1">
+          <h1 className="text-lg font-bold">レシピ候補</h1>
+          <p className="text-sm text-muted-foreground">登録するレシピを選んでください</p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={() => setCustomSelected(new Set())} disabled={submitting || selected.size === 0}>
+          全て外す
+        </Button>
       </div>
       <div className="flex-1 space-y-3">
         {candidates.map((c) => (


### PR DESCRIPTION
## Summary

- オンボーディング結果確認画面（レシピ候補一覧）のヘッダー右に「全て外す」ボタンを追加
- クリックすると全チェックボックスが一括解除される
- 既に全て外れている状態・送信中はボタンを無効化

Closes #65

## Test plan

- [ ] オンボーディング結果画面でレシピ候補が表示された際に「全て外す」ボタンが右上に表示される
- [ ] ボタンクリックで全チェックボックスが解除される
- [ ] 全解除後、「まとめて登録する」ボタンが disabled になる
- [ ] 全解除後、「全て外す」ボタン自体が disabled になる
- [ ] 個別チェックで再選択後、「全て外す」ボタンが再び有効になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)