### PR TITLE
feat: ユーザーが自己でアカウント削除できる機能を実装（Issue #86）

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,12 +1,16 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-05-24 (Issue #78 User-Agent Bot識別対応 PR #91 マージ)
+2026-05-25 (Issue #80 #81 #82 プライバシーポリシー修正 PR #93 マージ)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **本番稼働中**
 
 ## 直近の完了タスク
+- [x] **#80 #81 #82 プライバシーポリシーを実態に合わせて修正（PR #93）**
+  - #81: 第1条から「プロフィール画像」を削除（DBに保存していない）
+  - #80: 第4条 Gemini API 説明に第三者サイトのタイトル送信を明記
+  - #82: 第4条に Supabase をデータ処理事業者として追記
 - [x] **#78 User-AgentをBot識別可能な値に変更（PR #91）**
   - `src/lib/scraper/html-fetcher.ts` の Chrome なりすまし User-Agent を `RecipeHub-Bot/1.0` に変更
   - `NEXT_PUBLIC_APP_URL` 環境変数参照、未設定時は GitHub リポジトリ URL をフォールバック
@@ -25,7 +29,7 @@
 なし
 
 ## 次にやること（GitHub Issues で管理）
-- [ ] **develop → main PR を作成して本番リリース**（#79 オンボーディング削除、#78 User-Agent 修正、Vercel Analytics 等を本番反映）
+- [ ] **develop → main PR を作成して本番リリース**（#79 オンボーディング削除、#78 User-Agent 修正、#80〜#82 プライバシーポリシー修正、Vercel Analytics 等を本番反映）
 - [ ] **Vercel Dashboard で Node.js バージョンを 24.x に設定**（手動作業）
   - Settings → Build & Development Settings → Node.js Version → 24.x
 - [ ] **パッケージアップデートの継続**（スキップした項目）
@@ -66,14 +70,15 @@
 - `.nvmrc` - Node.js バージョン指定（24）
 - `package.json` - 各パッケージバージョン
 - `.claude/skills/update-packages/SKILL.md` - パッケージ更新スキル（Phase 4 改善済み）
+- `src/components/features/legal/privacy-content.tsx` - プライバシーポリシーコンポーネント
 
 ## コミット履歴（直近）
 ```
+599e72c Merge pull request #93 from mktu/feature/fix-privacy-policy-issues-80-81-82
+0a304cc fix: プライバシーポリシーを実態に合わせて修正（Issue #80 #81 #82）
+b3c55f7 docs: update SESSION.md for session handoff
 c35a9fb Merge pull request #91 from mktu/feature/fix-user-agent-bot-identification
 31ed0bb fix: User-AgentをBot識別可能な値に変更（Issue #78）
-bf3182a docs: update SESSION.md for session handoff
-ec16e1e docs: add src/lib/api/ to ARCHITECTURE.md directory structure
-664122e docs: レシピ解析フロー図にユーザー確認ステップを追加
 ```
 
 ## GitHubリポジトリ

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import { ChevronLeft } from 'lucide-react'
+import { AccountDeleteSection } from '@/components/features/settings/account-delete-section'
+
+export default function SettingsPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur">
+        <div className="container mx-auto flex max-w-2xl items-center p-4">
+          <Link href="/" className="mr-3 flex items-center text-muted-foreground hover:text-foreground">
+            <ChevronLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-lg font-semibold">設定</h1>
+        </div>
+      </header>
+      <main className="container mx-auto max-w-2xl space-y-6 p-4">
+        <AccountDeleteSection />
+      </main>
+    </div>
+  )
+}

--- a/src/app/api/auth/delete-user/route.ts
+++ b/src/app/api/auth/delete-user/route.ts
@@ -1,0 +1,33 @@
+import { createServerClient } from '@/lib/db/client'
+import { apiServerError } from '@/lib/api/error-response'
+import { NextRequest, NextResponse } from 'next/server'
+
+interface DeleteUserRequest {
+  lineUserId: string
+}
+
+/**
+ * DELETE /api/auth/delete-user
+ * ユーザーアカウントとすべての関連データを削除する
+ * users テーブルの ON DELETE CASCADE により recipes 等も自動削除される
+ */
+export async function DELETE(request: NextRequest) {
+  const body = (await request.json()) as DeleteUserRequest
+  const { lineUserId } = body
+
+  if (!lineUserId) {
+    return NextResponse.json({ error: 'lineUserId は必須です' }, { status: 400 })
+  }
+
+  const supabase = createServerClient()
+  const { error } = await supabase
+    .from('users')
+    .delete()
+    .eq('line_user_id', lineUserId)
+
+  if (error) {
+    return apiServerError(error, 'delete-user')
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/webhook/line/route.ts
+++ b/src/app/api/webhook/line/route.ts
@@ -26,6 +26,12 @@ function isHelpKeyword(text: string): boolean {
   return keywords.some((k) => text.trim().toLowerCase() === k.toLowerCase())
 }
 
+/** 退会・データ削除キーワードかどうかを判定 */
+function isWithdrawalKeyword(text: string): boolean {
+  const keywords = ['退会', 'アカウント削除', 'データ削除', '退会したい', 'アカウントを削除']
+  return keywords.includes(text.trim())
+}
+
 /** テストキーワードかどうかを判定（開発環境のみ有効） */
 function isTestKeyword(text: string): boolean {
   if (process.env.NODE_ENV !== 'development') return false
@@ -55,6 +61,17 @@ export async function ensureUser(lineUserId: string): Promise<void> {
   }
 }
 
+/** 退会・データ削除案内の応答 */
+async function replyWithdrawal(replyToken: string): Promise<void> {
+  await client.replyMessage({
+    replyToken,
+    messages: [{
+      type: 'text',
+      text: `アカウント削除について\n\nアカウントとすべてのレシピデータを削除するには、アプリの「設定」画面からアカウント削除を実行してください。\n\n⚠️ 削除後はデータを復元できません。\n\n※ このボットをブロックした場合も、データは自動的に削除されます。`,
+    }],
+  })
+}
+
 /** ヘルプメッセージの応答 */
 async function replyHelp(replyToken: string): Promise<void> {
   const helpText = `📖 RecipeHub の使い方
@@ -78,6 +95,7 @@ type KeywordEntry = [(t: string) => boolean, () => Promise<void>]
 function buildKeywordHandlers(replyToken: string, userId: string): KeywordEntry[] {
   return [
     [isHelpKeyword, () => replyHelp(replyToken)],
+    [isWithdrawalKeyword, () => replyWithdrawal(replyToken)],
     [isSearchKeyword, () => handleSearchCategoryPrompt(client, replyToken)],
     [isOkiniiriKeyword, () => handleFavorites(client, replyToken)],
     [isRecentlyAddedKeyword, () => handleRecentlyAdded(client, replyToken, userId)],
@@ -97,6 +115,22 @@ async function handleKeyword(text: string, replyToken: string, userId: string): 
   if (!match) return false
   await match[1]()
   return true
+}
+
+/** ブロック・友達削除イベントを処理（ユーザーデータを削除） */
+async function handleUnfollowEvent(event: webhook.Event): Promise<void> {
+  if (event.type !== 'unfollow' || !event.source?.userId) return
+  const { userId } = event.source
+
+  const supabase = createServerClient()
+  const { error } = await supabase
+    .from('users')
+    .delete()
+    .eq('line_user_id', userId)
+
+  if (error) {
+    console.error('[LINE Webhook] Failed to delete user on unfollow:', error)
+  }
 }
 
 /** 友達追加・ブロック解除イベントを処理 */
@@ -152,6 +186,7 @@ export async function POST(request: NextRequest) {
   const body = JSON.parse(bodyText) as { events: webhook.Event[] }
   await Promise.all(body.events.map((event) => Promise.all([
     handleFollowEvent(event),
+    handleUnfollowEvent(event),
     handleMessageEvent(event),
   ])))
 

--- a/src/components/features/home/home-client.tsx
+++ b/src/components/features/home/home-client.tsx
@@ -2,7 +2,9 @@
 
 import { useCallback } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { Settings } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
 import { useRecipes } from '@/hooks/use-recipes'
 import { useRecipeFilters, InitialFilters } from '@/hooks/use-recipe-filters'
@@ -106,7 +108,12 @@ function Header({ sortOrder, onSortChange }: HeaderProps) {
     <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur">
       <div className="container mx-auto flex max-w-2xl items-center justify-between p-4">
         <Image src="/logo.png" alt="RecipeHub" width={175} height={58} priority />
-        <SortSelect value={sortOrder} onChange={onSortChange} />
+        <div className="flex items-center gap-2">
+          <SortSelect value={sortOrder} onChange={onSortChange} />
+          <Link href="/settings" className="text-muted-foreground hover:text-foreground" aria-label="設定">
+            <Settings className="h-5 w-5" />
+          </Link>
+        </div>
       </div>
     </header>
   )

--- a/src/components/features/settings/account-delete-section.tsx
+++ b/src/components/features/settings/account-delete-section.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader,
+  AlertDialogTitle, AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { useAuth } from '@/lib/auth'
+
+function useAccountDelete() {
+  const { user, logout } = useAuth()
+  const router = useRouter()
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleDelete() {
+    if (!user?.lineUserId) return
+    setIsDeleting(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/auth/delete-user', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lineUserId: user.lineUserId }),
+      })
+      if (!res.ok) throw new Error('削除に失敗しました')
+      await logout()
+      router.replace('/')
+    } catch {
+      setError('アカウントの削除に失敗しました。しばらく経ってから再度お試しください。')
+      setIsDeleting(false)
+    }
+  }
+
+  return { isDeleting, error, handleDelete }
+}
+
+interface DeleteDialogProps {
+  isDeleting: boolean
+  onDelete: () => void
+}
+
+function DeleteDialog({ isDeleting, onDelete }: DeleteDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" disabled={isDeleting}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          {isDeleting ? '削除中...' : 'アカウントを削除'}
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>アカウントを削除しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            すべてのレシピデータが完全に削除されます。この操作は取り消せません。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onDelete}
+            disabled={isDeleting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            削除する
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export function AccountDeleteSection() {
+  const { isDeleting, error, handleDelete } = useAccountDelete()
+
+  return (
+    <section className="rounded-lg border border-destructive/30 p-4">
+      <h2 className="mb-1 text-sm font-semibold text-destructive">危険な操作</h2>
+      <p className="mb-4 text-sm text-muted-foreground">
+        アカウントを削除すると、すべてのレシピデータも完全に削除されます。この操作は取り消せません。
+      </p>
+      {error && <p className="mb-3 text-sm text-destructive">{error}</p>}
+      <DeleteDialog isDeleting={isDeleting} onDelete={handleDelete} />
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

- `DELETE /api/auth/delete-user` エンドポイントを追加（`users` 削除で recipes 等も CASCADE 自動削除）
- LINE Bot の `unfollow` イベント（ブロック・友達削除）でユーザーデータを自動削除
- LINE Bot に「退会」「データ削除」などのキーワードでアプリ設定画面への誘導メッセージを追加
- `/settings` ページにアカウント削除セクションを実装（確認ダイアログ付き）
- ホームヘッダーに設定アイコン（歯車）リンクを追加

## Test plan

- [ ] LINE Bot に「退会」と送ると設定画面への案内メッセージが返ってくる
- [ ] LINE Bot をブロック → ユーザーレコードと関連レシピが DB から削除される
- [ ] ホームヘッダーの歯車アイコンから `/settings` に遷移できる
- [ ] 設定画面の「アカウントを削除」ボタン → 確認ダイアログ → 削除実行 → トップへリダイレクト
- [ ] 削除後に DB の `users` レコードと `recipes` が消えていることを確認

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)