### PR TITLE
fix: API の lineUserId を ID トークンで検証し IDOR を防ぐ (Issue #101)

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,12 +1,21 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-06-07 (Issue #97 プライバシーポリシー・利用規約更新 develop マージ完了)
+2026-06-07 (/legal-check 実施 → Issue #100/#101/#102 起票、#100 develop マージ完了)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **本番稼働中**
 
 ## 直近の完了タスク
+- [x] **/legal-check（法的リスクチェック）を実施し、要対応3件を Issue 化**
+  - #100: 利用規約 第6条と実装の不一致（robots.txt/解析禁止判定が未実装）→ **対応済み**
+  - #101: アクセス制御 - API が lineUserId を無検証で受け取り RLS がバイパス（IDOR リスク・高）→ 未着手
+  - #102: プライバシーポリシーの Gemini 学習利用記述が API プランと整合するか要確認（中）→ 未着手
+  - 良好だった点: スクレイピングは構造化メタデータのみ（本文非取得）、LINE 退会/削除フローは整合
+- [x] **#100 利用規約 第6条を解析の実態に合わせて修正（PR #103→develop反映済み）**
+  - 落とし所は案B（文言修正）を採用。robots.txt 実装追加（案A）は単発取得のため過剰と判断
+  - 保証できない約束（「利用規約により禁止されたコンテンツは解析しない」）を削除
+  - 実態を明記: 構造化メタデータのみ取得・本文非複製・robots.txt 等の指定を尊重
 - [x] **#97 プライバシーポリシー・利用規約を実装に合わせて更新（PR #98→develop反映済み）**
   - 第5条: アカウント削除案内を「設定画面から削除できます」に変更
   - 第4条: Gemini API の用途に食材名エイリアス自動生成を追記
@@ -29,7 +38,12 @@
 なし
 
 ## 次にやること（GitHub Issues で管理）
-- [ ] **develop → main PR を作成して本番リリース**（#86 アカウント削除機能 + #97 法的文書更新を本番反映）
+- [ ] **#101 アクセス制御の修正（最優先・セキュリティ）**
+  - API が `lineUserId` を body/ヘッダから無検証で受け取り、Service Role キーで RLS をバイパス（IDOR）
+  - LIFF ID トークン検証ミドルウェアの導入。`/security-review` の併用を推奨
+- [ ] **#102 Gemini API プランの確認**
+  - 使用キーが課金プラン有効か確認 → 無料枠ならプライバシーポリシー記述を修正 or 有料化
+- [ ] **develop → main PR を作成して本番リリース**（#86 アカウント削除 + #97/#100 法的文書更新を本番反映）
   - Vercel 本番環境に `LINE_LOGIN_CHANNEL_SECRET` の設定が必要
 - [ ] **Vercel Dashboard で Node.js バージョンを 24.x に設定**（手動作業）
   - Settings → Build & Development Settings → Node.js Version → 24.x
@@ -71,11 +85,11 @@
 
 ## コミット履歴（直近）
 ```
+b37e68d Merge pull request #103 from mktu/feature/fix-terms-scraping-clause-100
+46cfcc6 docs: 利用規約 第6条を解析の実態に合わせて修正 (Issue #100)
+83800b8 docs: update SESSION.md for session handoff
 e2ee3e8 Merge pull request #98 from mktu/feature/docs-legal-update-97
 c3d50ef docs: プライバシーポリシー・利用規約を実装に合わせて更新 (Issue #97)
-6d40df8 docs: update SESSION.md for session handoff
-13a5ff0 fix: LINE Login チャンネル ID を NEXT_PUBLIC_LIFF_ID から取得
-50cb8ef fix: deauthorize API の呼び出し方を公式仕様に修正
 ```
 
 ## GitHubリポジトリ

--- a/src/app/api/auth/delete-user/route.ts
+++ b/src/app/api/auth/delete-user/route.ts
@@ -1,9 +1,9 @@
 import { createServerClient } from '@/lib/db/client'
 import { apiServerError } from '@/lib/api/error-response'
+import { requireLineUser } from '@/lib/api/auth-guard'
 import { NextRequest, NextResponse } from 'next/server'
 
 interface DeleteUserRequest {
-  lineUserId: string
   accessToken: string
 }
 
@@ -55,11 +55,15 @@ async function deauthorize(channelAccessToken: string, userAccessToken: string):
  * users テーブルの ON DELETE CASCADE により recipes 等も自動削除される
  */
 export async function DELETE(request: NextRequest) {
-  const body = (await request.json()) as DeleteUserRequest
-  const { lineUserId, accessToken } = body
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+  const lineUserId = auth
 
-  if (!lineUserId || !accessToken) {
-    return NextResponse.json({ error: 'lineUserId と accessToken は必須です' }, { status: 400 })
+  const body = (await request.json()) as DeleteUserRequest
+  const { accessToken } = body
+
+  if (!accessToken) {
+    return NextResponse.json({ error: 'accessToken は必須です' }, { status: 400 })
   }
 
   try {

--- a/src/app/api/auth/ensure-user/route.ts
+++ b/src/app/api/auth/ensure-user/route.ts
@@ -1,22 +1,26 @@
 import { createServerClient } from '@/lib/db/client'
 import { apiServerError } from '@/lib/api/error-response'
+import { requireLineUser } from '@/lib/api/auth-guard'
 import type { Tables } from '@/types/database'
 import { NextRequest, NextResponse } from 'next/server'
 
 interface EnsureUserRequest {
-  lineUserId: string
   displayName: string
 }
 
 type User = Tables<'users'>
 
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as EnsureUserRequest
-  const { lineUserId, displayName } = body
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+  const lineUserId = auth
 
-  if (!lineUserId || !displayName) {
+  const body = (await request.json()) as EnsureUserRequest
+  const { displayName } = body
+
+  if (!displayName) {
     return NextResponse.json(
-      { error: 'lineUserId と displayName は必須です' },
+      { error: 'displayName は必須です' },
       { status: 400 }
     )
   }

--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { fetchRecipeById, deleteRecipe, updateRecipe } from '@/lib/db/queries/recipes'
 import { apiServerError } from '@/lib/api/error-response'
+import { requireLineUser } from '@/lib/api/auth-guard'
 import type { UpdateRecipeInput } from '@/types/recipe'
 
 interface RouteContext {
@@ -13,11 +14,9 @@ interface RouteContext {
  */
 export async function GET(request: NextRequest, context: RouteContext) {
   const { id } = await context.params
-  const lineUserId = request.headers.get('x-line-user-id')
-
-  if (!lineUserId) {
-    return NextResponse.json({ error: '認証が必要です' }, { status: 401 })
-  }
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+  const lineUserId = auth
 
   const { data, error } = await fetchRecipeById(lineUserId, id)
 
@@ -38,11 +37,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
  */
 export async function DELETE(request: NextRequest, context: RouteContext) {
   const { id } = await context.params
-  const lineUserId = request.headers.get('x-line-user-id')
-
-  if (!lineUserId) {
-    return NextResponse.json({ error: '認証が必要です' }, { status: 401 })
-  }
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+  const lineUserId = auth
 
   const { error } = await deleteRecipe(lineUserId, id)
 
@@ -59,11 +56,9 @@ export async function DELETE(request: NextRequest, context: RouteContext) {
  */
 export async function PATCH(request: NextRequest, context: RouteContext) {
   const { id } = await context.params
-  const lineUserId = request.headers.get('x-line-user-id')
-
-  if (!lineUserId) {
-    return NextResponse.json({ error: '認証が必要です' }, { status: 401 })
-  }
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+  const lineUserId = auth
 
   const body = await request.json()
 

--- a/src/app/api/recipes/list/route.ts
+++ b/src/app/api/recipes/list/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { apiServerError } from '@/lib/api/error-response'
+import { requireLineUser } from '@/lib/api/auth-guard'
 import type { SortOrder } from '@/types/recipe'
 
 interface ListRecipesRequest {
@@ -48,12 +49,12 @@ async function fetchViaEdgeFunction(params: ListRecipesRequest) {
 export async function POST(request: NextRequest) {
   const startTime = Date.now()
 
-  const body = (await request.json()) as ListRecipesRequest
-  const { lineUserId, searchQuery, ingredientIds = [], sourceNames = [], sortOrder = 'newest' } = body
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+  const lineUserId = auth
 
-  if (!lineUserId) {
-    return NextResponse.json({ error: 'lineUserId は必須です' }, { status: 400 })
-  }
+  const body = (await request.json()) as ListRecipesRequest
+  const { searchQuery, ingredientIds = [], sourceNames = [], sortOrder = 'newest' } = body
 
   try {
     const result = await fetchViaEdgeFunction({

--- a/src/app/api/recipes/parse/route.ts
+++ b/src/app/api/recipes/parse/route.ts
@@ -1,10 +1,10 @@
 import { parseRecipe } from '@/lib/recipe/parse-recipe'
 import { createServerClient } from '@/lib/db/client'
+import { requireLineUser } from '@/lib/api/auth-guard'
 import { NextRequest, NextResponse } from 'next/server'
 
 interface ParseRecipeRequest {
   url: string
-  lineUserId: string
 }
 
 /**
@@ -12,12 +12,12 @@ interface ParseRecipeRequest {
  * URLからレシピ情報を解析する
  */
 export async function POST(request: NextRequest) {
-  const body = (await request.json()) as ParseRecipeRequest
-  const { url, lineUserId } = body
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+  const lineUserId = auth
 
-  if (!lineUserId) {
-    return NextResponse.json({ error: 'lineUserId は必須です' }, { status: 400 })
-  }
+  const body = (await request.json()) as ParseRecipeRequest
+  const { url } = body
 
   if (!url) {
     return NextResponse.json({ error: 'URL は必須です' }, { status: 400 })

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -1,5 +1,6 @@
 import { createRecipe } from '@/lib/db/queries/recipes'
 import { apiServerError } from '@/lib/api/error-response'
+import { requireLineUser } from '@/lib/api/auth-guard'
 import type { CreateRecipeInput } from '@/types/recipe'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -8,12 +9,13 @@ import { NextRequest, NextResponse } from 'next/server'
  * 新規レシピを作成
  */
 export async function POST(request: NextRequest) {
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+  const lineUserId = auth
+
   const body = (await request.json()) as CreateRecipeInput
 
   // バリデーション
-  if (!body.lineUserId) {
-    return NextResponse.json({ error: 'lineUserId は必須です' }, { status: 400 })
-  }
   if (!body.url) {
     return NextResponse.json({ error: 'URL は必須です' }, { status: 400 })
   }
@@ -21,8 +23,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'タイトルは必須です' }, { status: 400 })
   }
 
-  // レシピ作成
-  const { data, error } = await createRecipe(body)
+  // 検証済みの lineUserId で上書き（body の自己申告値は信用しない）
+  const { data, error } = await createRecipe({ ...body, lineUserId })
 
   if (error) {
     // UNIQUE制約違反（重複URL）

--- a/src/app/api/track/recipe/[id]/route.ts
+++ b/src/app/api/track/recipe/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse, after } from 'next/server'
 import { createServerClient } from '@/lib/db/client'
 import { recordRecipeView } from '@/lib/db/queries/recipes'
+import { requireLineUser } from '@/lib/api/auth-guard'
 
 interface RouteContext {
   params: Promise<{ id: string }>
@@ -31,7 +32,10 @@ export async function GET(_request: NextRequest, context: RouteContext) {
  * POST /api/track/recipe/[id]
  * LIFF用: 閲覧を記録して 204 を返す
  */
-export async function POST(_request: NextRequest, context: RouteContext) {
+export async function POST(request: NextRequest, context: RouteContext) {
+  const auth = await requireLineUser(request)
+  if (auth instanceof NextResponse) return auth
+
   const { id } = await context.params
 
   await recordRecipeView(id)

--- a/src/components/features/home/home-client.tsx
+++ b/src/components/features/home/home-client.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Settings } from 'lucide-react'
 import { useAuth } from '@/lib/auth'
+import { useAuthedFetch } from '@/hooks/use-authed-fetch'
 import { useRecipes } from '@/hooks/use-recipes'
 import { useRecipeFilters, InitialFilters } from '@/hooks/use-recipe-filters'
 export type { InitialFilters }
@@ -23,10 +24,11 @@ interface HomeClientProps {
 
 function useRecipeHandlers() {
   const router = useRouter()
+  const authedFetch = useAuthedFetch()
   const handleRecipeClick = useCallback((id: string) => {
-    fetch(`/api/track/recipe/${id}`, { method: 'POST' }).catch(() => {})
+    authedFetch(`/api/track/recipe/${id}`, { method: 'POST' }).catch(() => {})
     router.push(`/recipes/${id}`)
-  }, [router])
+  }, [router, authedFetch])
   const handleAddRecipe = useCallback(() => router.push('/recipes/add'), [router])
   return { handleRecipeClick, handleAddRecipe }
 }

--- a/src/components/features/recipe-detail/recipe-detail-wrapper.tsx
+++ b/src/components/features/recipe-detail/recipe-detail-wrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { useAuth } from '@/lib/auth'
+import { useAuthedFetch } from '@/hooks/use-authed-fetch'
 import type { RecipeDetail } from '@/types/recipe'
 import { RecipeDetailPage } from './recipe-detail-page'
 
@@ -11,6 +12,7 @@ interface RecipeDetailWrapperProps {
 
 export function RecipeDetailWrapper({ recipeId }: RecipeDetailWrapperProps) {
   const { user, isLoading: authLoading, isAuthenticated } = useAuth()
+  const authedFetch = useAuthedFetch()
   const [recipe, setRecipe] = useState<RecipeDetail | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -20,9 +22,7 @@ export function RecipeDetailWrapper({ recipeId }: RecipeDetailWrapperProps) {
     setIsLoading(true)
     setError(null)
     try {
-      const res = await fetch(`/api/recipes/${recipeId}`, {
-        headers: { 'x-line-user-id': user.lineUserId },
-      })
+      const res = await authedFetch(`/api/recipes/${recipeId}`)
       if (!res.ok) {
         setError(res.status === 404 ? 'レシピが見つかりません' : 'レシピの取得に失敗しました')
         return
@@ -33,7 +33,7 @@ export function RecipeDetailWrapper({ recipeId }: RecipeDetailWrapperProps) {
     } finally {
       setIsLoading(false)
     }
-  }, [recipeId, user])
+  }, [recipeId, user, authedFetch])
 
   useEffect(() => {
     if (authLoading || !user) return

--- a/src/components/features/recipe-detail/use-recipe-actions.ts
+++ b/src/components/features/recipe-detail/use-recipe-actions.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from 'react'
 import { useAuth } from '@/lib/auth'
+import { useAuthedFetch } from '@/hooks/use-authed-fetch'
 
 interface UseRecipeActionsOptions {
   recipeId: string
@@ -10,30 +11,27 @@ interface UseRecipeActionsOptions {
 
 export function useRecipeActions({ recipeId, initialMemo }: UseRecipeActionsOptions) {
   const { user } = useAuth()
+  const authedFetch = useAuthedFetch()
   const [memo, setMemo] = useState(initialMemo)
 
   const updateMemo = useCallback(async (newMemo: string) => {
     if (!user) throw new Error('認証が必要です')
-    const res = await fetch(`/api/recipes/${recipeId}`, {
+    const res = await authedFetch(`/api/recipes/${recipeId}`, {
       method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-line-user-id': user.lineUserId,
-      },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ memo: newMemo }),
     })
     if (!res.ok) throw new Error('メモの更新に失敗しました')
     setMemo(newMemo)
-  }, [recipeId, user])
+  }, [recipeId, user, authedFetch])
 
   const deleteRecipe = useCallback(async () => {
     if (!user) throw new Error('認証が必要です')
-    const res = await fetch(`/api/recipes/${recipeId}`, {
+    const res = await authedFetch(`/api/recipes/${recipeId}`, {
       method: 'DELETE',
-      headers: { 'x-line-user-id': user.lineUserId },
     })
     if (!res.ok) throw new Error('削除に失敗しました')
-  }, [recipeId, user])
+  }, [recipeId, user, authedFetch])
 
   return { memo, updateMemo, deleteRecipe }
 }

--- a/src/components/features/recipe-detail/use-rescrape.ts
+++ b/src/components/features/recipe-detail/use-rescrape.ts
@@ -2,10 +2,12 @@
 
 import { useState, useCallback } from 'react'
 import { useAuth } from '@/lib/auth'
+import { useAuthedFetch } from '@/hooks/use-authed-fetch'
 import type { ParsedRecipe } from '@/types/recipe'
 
 export function useRescrape() {
   const { user } = useAuth()
+  const authedFetch = useAuthedFetch()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const [result, setResult] = useState<ParsedRecipe | null>(null)
@@ -17,7 +19,7 @@ export function useRescrape() {
     setResult(null)
 
     try {
-      const res = await fetch('/api/recipes/parse', {
+      const res = await authedFetch('/api/recipes/parse', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ url, lineUserId: user.lineUserId }),
@@ -32,7 +34,7 @@ export function useRescrape() {
     } finally {
       setIsLoading(false)
     }
-  }, [user])
+  }, [user, authedFetch])
 
   return { rescrape, isLoading, error, result }
 }

--- a/src/components/features/settings/account-delete-section.tsx
+++ b/src/components/features/settings/account-delete-section.tsx
@@ -10,9 +10,11 @@ import {
   AlertDialogTitle, AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { useAuth } from '@/lib/auth'
+import { useAuthedFetch } from '@/hooks/use-authed-fetch'
 
 function useAccountDelete() {
   const { user, logout, getAccessToken } = useAuth()
+  const authedFetch = useAuthedFetch()
   const router = useRouter()
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -27,7 +29,7 @@ function useAccountDelete() {
     setIsDeleting(true)
     setError(null)
     try {
-      const res = await fetch('/api/auth/delete-user', {
+      const res = await authedFetch('/api/auth/delete-user', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ lineUserId: user.lineUserId, accessToken }),

--- a/src/hooks/use-authed-fetch.ts
+++ b/src/hooks/use-authed-fetch.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useAuth } from '@/lib/auth'
+import { authedFetch } from '@/lib/api/authed-fetch'
+
+/**
+ * 現在の LINE ID トークンを `Authorization: Bearer` ヘッダに付与する fetch を返すフック。
+ *
+ * @example
+ * ```ts
+ * const fetchWithAuth = useAuthedFetch()
+ * const res = await fetchWithAuth('/api/recipes/list', { method: 'POST', body })
+ * ```
+ */
+export function useAuthedFetch() {
+  const { getIdToken } = useAuth()
+  return useCallback(
+    (input: RequestInfo | URL, init?: RequestInit) => authedFetch(getIdToken(), input, init),
+    [getIdToken]
+  )
+}

--- a/src/hooks/use-create-recipe.ts
+++ b/src/hooks/use-create-recipe.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback } from 'react'
+import { useAuthedFetch } from '@/hooks/use-authed-fetch'
 import type { CreateRecipeInput } from '@/types/recipe'
 
 interface CreateRecipeResult {
@@ -17,6 +18,7 @@ interface UseCreateRecipeReturn {
  * レシピを新規作成するhook
  */
 export function useCreateRecipe(): UseCreateRecipeReturn {
+  const authedFetch = useAuthedFetch()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
 
@@ -26,7 +28,7 @@ export function useCreateRecipe(): UseCreateRecipeReturn {
       setError(null)
 
       try {
-        const response = await fetch('/api/recipes', {
+        const response = await authedFetch('/api/recipes', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(input),
@@ -47,7 +49,7 @@ export function useCreateRecipe(): UseCreateRecipeReturn {
         setIsLoading(false)
       }
     },
-    []
+    [authedFetch]
   )
 
   return { createRecipe, isLoading, error }

--- a/src/hooks/use-recipes.ts
+++ b/src/hooks/use-recipes.ts
@@ -2,7 +2,10 @@
 
 import useSWR from 'swr'
 import { useAuth } from '@/lib/auth'
+import { useAuthedFetch } from '@/hooks/use-authed-fetch'
 import type { SortOrder, RecipeWithIngredients } from '@/types/recipe'
+
+type AuthedFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 interface UseRecipesOptions {
   searchQuery?: string
@@ -35,8 +38,8 @@ interface FetchResult {
 
 const EMPTY_RESULT: FetchResult = { data: [], availableSourceNames: [] }
 
-async function fetchRecipesApi(params: FetchParams): Promise<FetchResult> {
-  const response = await fetch('/api/recipes/list', {
+async function fetchRecipesApi(params: FetchParams, authedFetch: AuthedFetch): Promise<FetchResult> {
+  const response = await authedFetch('/api/recipes/list', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(params),
@@ -58,6 +61,7 @@ function buildSwrKey(
 export function useRecipes(options: UseRecipesOptions = {}): UseRecipesReturn {
   const { searchQuery = '', ingredientIds = [], sourceNames = [], sortOrder = 'newest' } = options
   const { user } = useAuth()
+  const authedFetch = useAuthedFetch()
 
   const swrKey = user ? buildSwrKey(user.lineUserId, searchQuery, ingredientIds, sourceNames, sortOrder) : null
 
@@ -69,7 +73,7 @@ export function useRecipes(options: UseRecipesOptions = {}): UseRecipesReturn {
       ingredientIds,
       sourceNames,
       sortOrder,
-    }),
+    }, authedFetch),
     {
       revalidateOnFocus: false,
       dedupingInterval: 300,

--- a/src/hooks/use-update-recipe.ts
+++ b/src/hooks/use-update-recipe.ts
@@ -2,10 +2,12 @@
 
 import { useState, useCallback } from 'react'
 import { useAuth } from '@/lib/auth'
+import { useAuthedFetch } from '@/hooks/use-authed-fetch'
 import type { UpdateRecipeInput } from '@/types/recipe'
 
 export function useUpdateRecipe(recipeId: string) {
   const { user } = useAuth()
+  const authedFetch = useAuthedFetch()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
 
@@ -19,12 +21,9 @@ export function useUpdateRecipe(recipeId: string) {
       setError(null)
 
       try {
-        const res = await fetch(`/api/recipes/${recipeId}`, {
+        const res = await authedFetch(`/api/recipes/${recipeId}`, {
           method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-            'x-line-user-id': user.lineUserId,
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(input),
         })
 
@@ -41,7 +40,7 @@ export function useUpdateRecipe(recipeId: string) {
         setIsLoading(false)
       }
     },
-    [recipeId, user]
+    [recipeId, user, authedFetch]
   )
 
   return { updateRecipe, isLoading, error }

--- a/src/lib/api/auth-guard.ts
+++ b/src/lib/api/auth-guard.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { verifyLineToken } from '@/lib/auth/verify-line-token'
+
+/**
+ * `Authorization: Bearer <idToken>` ヘッダから ID トークンを取り出す。
+ */
+function extractBearerToken(request: NextRequest): string | null {
+  const header = request.headers.get('authorization')
+  if (!header?.startsWith('Bearer ')) return null
+  return header.slice('Bearer '.length).trim() || null
+}
+
+/**
+ * リクエストの ID トークンを検証し、検証済み lineUserId を返す。
+ *
+ * 各 API route の冒頭で呼び出す。戻り値が NextResponse の場合は
+ * 認証失敗なので即 return すること。文字列なら検証済み lineUserId。
+ * body / ヘッダの自己申告 lineUserId は信用せず、この戻り値のみを使う。
+ *
+ * 使用例:
+ * ```ts
+ * const auth = await requireLineUser(request)
+ * if (auth instanceof NextResponse) return auth
+ * const lineUserId = auth
+ * ```
+ */
+export async function requireLineUser(request: NextRequest): Promise<string | NextResponse> {
+  const idToken = extractBearerToken(request)
+  const lineUserId = await verifyLineToken(idToken)
+
+  if (!lineUserId) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 })
+  }
+
+  return lineUserId
+}

--- a/src/lib/api/authed-fetch.ts
+++ b/src/lib/api/authed-fetch.ts
@@ -1,0 +1,18 @@
+/**
+ * LINE ID トークンを `Authorization: Bearer` ヘッダに付与して fetch するヘルパー。
+ *
+ * idToken は `useAuth().getIdToken()` で取得して渡す。
+ * dev モードでは null になるが、その場合ヘッダは付与されず、
+ * サーバー側の検証が dev バイパスで通る（verify-line-token.ts 参照）。
+ */
+export function authedFetch(
+  idToken: string | null,
+  input: RequestInfo | URL,
+  init: RequestInit = {}
+): Promise<Response> {
+  const headers = new Headers(init.headers)
+  if (idToken) {
+    headers.set('Authorization', `Bearer ${idToken}`)
+  }
+  return fetch(input, { ...init, headers })
+}

--- a/src/lib/auth/context.tsx
+++ b/src/lib/auth/context.tsx
@@ -69,6 +69,8 @@ export function AuthProvider({ children, adapter }: AuthProviderProps) {
 
   const getAccessToken = useCallback(() => adapter.getAccessToken(), [adapter])
 
+  const getIdToken = useCallback(() => adapter.getIdToken(), [adapter])
+
   const value: AuthContextValue = {
     user,
     status: isLoading ? 'loading' : user ? 'authenticated' : 'unauthenticated',
@@ -78,6 +80,7 @@ export function AuthProvider({ children, adapter }: AuthProviderProps) {
     logout,
     relogin,
     getAccessToken,
+    getIdToken,
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/src/lib/auth/providers/dev-provider.ts
+++ b/src/lib/auth/providers/dev-provider.ts
@@ -26,5 +26,9 @@ export function createDevProvider(): AuthProviderAdapter {
     getAccessToken(): null {
       return null
     },
+
+    getIdToken(): null {
+      return null
+    },
   }
 }

--- a/src/lib/auth/providers/liff-provider.ts
+++ b/src/lib/auth/providers/liff-provider.ts
@@ -79,6 +79,8 @@ export function createLiffProvider(id: string): AuthProviderAdapter {
     },
 
     getAccessToken: () => liff?.getAccessToken() ?? null,
+
+    getIdToken: () => liff?.getIDToken() ?? null,
   }
 
   return adapter

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -29,6 +29,8 @@ export interface AuthContextValue {
   relogin: () => Promise<void>
   /** LINE アクセストークンを取得（deauthorize 用） */
   getAccessToken: () => string | null
+  /** LINE ID トークンを取得（API 認証用） */
+  getIdToken: () => string | null
 }
 
 /** 認証プロバイダーのインターフェース */
@@ -45,4 +47,6 @@ export interface AuthProviderAdapter {
   relogin: () => Promise<void>
   /** LINE アクセストークンを取得（deauthorize 用） */
   getAccessToken: () => string | null
+  /** LINE ID トークンを取得（API 認証用） */
+  getIdToken: () => string | null
 }

--- a/src/lib/auth/verify-line-token.ts
+++ b/src/lib/auth/verify-line-token.ts
@@ -1,0 +1,69 @@
+import { DEV_USER } from './constants'
+
+/**
+ * LIFF チャネル ID（LINE Login チャネル）を返す。
+ * NEXT_PUBLIC_LIFF_ID は "<channelId>-<liffId>" 形式のため先頭を取り出す。
+ * 未設定（dev モード）の場合は null。
+ */
+function getLineChannelId(): string | null {
+  return process.env.NEXT_PUBLIC_LIFF_ID?.split('-')[0] || null
+}
+
+interface VerifyResponse {
+  /** ユーザー ID（LINE userId） */
+  sub: string
+  /** audience（チャネル ID） */
+  aud: string
+  iss: string
+  exp: number
+}
+
+/**
+ * LIFF の ID トークン（JWT）を LINE のエンドポイントで検証し、
+ * 検証済みの lineUserId（sub）を返す。
+ *
+ * - 署名・有効期限・audience（チャネル ID）は LINE 側で検証される
+ * - 失敗時は null
+ *
+ * dev モード（NEXT_PUBLIC_LIFF_ID 未設定）では検証をスキップし、
+ * DEV_USER の lineUserId を返してローカル開発を維持する。
+ */
+export async function verifyLineToken(idToken: string | null): Promise<string | null> {
+  const channelId = getLineChannelId()
+
+  // dev モード: 検証スキップ
+  if (!channelId) {
+    return DEV_USER.lineUserId
+  }
+
+  if (!idToken) return null
+
+  try {
+    const res = await fetch('https://api.line.me/oauth2/v2.1/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        id_token: idToken,
+        client_id: channelId,
+      }),
+    })
+
+    if (!res.ok) {
+      console.warn('[verifyLineToken] verify failed:', res.status)
+      return null
+    }
+
+    const data = (await res.json()) as VerifyResponse
+
+    // 二重チェック: audience がこのチャネルと一致すること
+    if (data.aud !== channelId) {
+      console.warn('[verifyLineToken] aud mismatch')
+      return null
+    }
+
+    return data.sub
+  } catch (err) {
+    console.error('[verifyLineToken]', err)
+    return null
+  }
+}


### PR DESCRIPTION
## 概要

Closes #101

API が `lineUserId` を **body / ヘッダから自己申告で受け取り無検証で使用**しており、サーバーは Service Role キーで Supabase に接続して RLS をバイパスしていた。結果として他人の LINE userId を知れば他人のレシピを読み書きできる **IDOR リスク**があった。

LINE **ID トークン**（LIFF `getIDToken()`）をサーバーで検証し、**検証済みの userId のみ**を使うよう全ユーザー操作 API を統一する。

## 変更内容

### サーバー（検証基盤）
- `src/lib/auth/verify-line-token.ts`（新規）: ID トークンを LINE の `oauth2/v2.1/verify` で検証し `sub`(=userId) を返す。`aud` 二重チェック付き。**dev モード（`NEXT_PUBLIC_LIFF_ID` 空）はバイパス**して `dev-user-001` を返す
- `src/lib/api/auth-guard.ts`（新規）: `requireLineUser(request)` で `Authorization: Bearer <idToken>` を検証し、検証済み userId か 401 を返す

### サーバー（全 route で検証済み userId を使用）
自己申告 lineUserId を無視し、検証済み値のみ使用:
- `recipes/list` POST / `recipes/parse` POST
- `recipes/[id]` GET・DELETE・PATCH（`x-line-user-id` ヘッダ廃止）
- `recipes` POST（create — 検証済み id で上書き）
- `auth/ensure-user` POST（なりすまし作成防止）/ `auth/delete-user` DELETE（検証済み id のみ削除）
- `track/recipe/[id]` POST

### クライアント
- `AuthProviderAdapter` / `AuthContextValue` に `getIdToken` を追加（liff/dev 両プロバイダ実装）
- `src/hooks/use-authed-fetch.ts`（新規）: `useAuthedFetch()` で `Authorization` ヘッダを自動付与
- 全 API 呼び出しを `useAuthedFetch` 経由に統一、無効化された `x-line-user-id` ヘッダを除去

## 対象外（適切な代替保護あり）
- `webhook/line` POST: LINE 署名検証（`validateSignature`）で保護済み
- `track/recipe/[id]` **GET**: LINE チャット内リンク用の redirect のみ・ユーザーデータ非依存（open-redirect 対策済み）。トークンを付与できない箇所のため除外

## 動作確認
- [x] `npm run lint` / `npm run build`
- [x] ローカル（dev モード）: 一覧 / 追加 / 詳細 / メモ更新 / 削除 / 再スクレイプ が従来通り動作
- [ ] **ステージングで LIFF ログイン後の全フロー確認**（レビュアー）
- [ ] **攻撃シナリオ**: Authorization 無し → 401 / 改ざんトークン → 401 / 他人の recipe id アクセス → 404

## 補足
- 本格的な RLS 適用（検証済み userId で Supabase JWT/RLS を効かせる）は別 Issue に分離（本 PR はアプリ層でのトークン検証に集中）
- API コールの typed 関数レイヤーへの集約リファクタは #106 で別途対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)