### PR TITLE
feat: JSON-LD/__NEXT_DATA__ 失敗時に OGP からタイトルを取得（Issue #105）

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,12 +1,16 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-06-15 (/doc-check-logic で ARCHITECTURE.md 認証フローを検証・整合化、未使用 ensure-user API を削除して develop に直接プッシュ)
+2026-06-15 (PR #112 を develop→main マージし本番を最新化。docs 整合・未使用 ensure-user API 削除を本番反映)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **本番稼働中**
 
 ## 直近の完了タスク
+- [x] **PR #112 を develop→main マージし本番を最新化（merged 2026-06-15）**
+  - 内容: docs 整合（ARCHITECTURE.md / SESSION.md）・未使用 ensure-user API 削除を本番反映
+  - PR #108（#86 アカウント削除 + #97/#100 法的文書 + #101 IDOR 修正）に続くドキュメント追従リリース
+  - develop と main は完全に同期済み（差分なし）
 - [x] **/doc-check-logic でアーキテクチャ整合性を検証し認証フローを修正（commit 896f853→develop直接push済み）**
   - 検証範囲: 認証 / レシピ解析 / 食材名寄せの3セクション（git diff main...HEAD から自動推論）
   - レシピ解析フロー: ARCHITECTURE.md と一致（JSON-LD→__NEXT_DATA__→空結果）。※CLAUDE.md L17 の「Jina Reader」記述のみ実装と乖離（実装は __NEXT_DATA__）→ 未対応
@@ -58,8 +62,6 @@
 - [ ] **CLAUDE.md L17 の Scraper 記述を実装に合わせて修正**（「Jina Reader API（フォールバック）」→ 実装は `__NEXT_DATA__` 抽出。/doc-check-logic で発見、ARCHITECTURE.md 側は整合済み）
 - [ ] **#102 Gemini API プランの確認**
   - 使用キーが課金プラン有効か確認 → 無料枠ならプライバシーポリシー記述を修正 or 有料化
-- [ ] **develop → main PR を作成して本番リリース**（#86 アカウント削除 + #97/#100 法的文書更新を本番反映）
-  - Vercel 本番環境に `LINE_LOGIN_CHANNEL_SECRET` の設定が必要
 - [ ] **Vercel Dashboard で Node.js バージョンを 24.x に設定**（手動作業）
   - Settings → Build & Development Settings → Node.js Version → 24.x
 - [ ] **パッケージアップデートの継続**（スキップした項目）
@@ -76,8 +78,6 @@
   - 現状 `auth.uid()` ベースのポリシーは Supabase Auth 不在で空振り。先に単一データアクセス層・クロスユーザーテストが費用対効果高
 
 ## ブロッカー・注意点
-- **本番リリース前に Vercel 本番環境へ `LINE_LOGIN_CHANNEL_SECRET` を設定すること**
-  - LINE Developers Console → LINE Login チャンネル → Basic settings → Channel secret
 - **PR は必ず `--base develop` を指定する**（`/create-pr` スキルを使うと安全）
   - 過去に `main` へ誤マージした実績あり（PR #95）
 - **Vercel Preview の Deployment Protection は Off にしている**
@@ -109,11 +109,11 @@
 
 ## コミット履歴（直近）
 ```
+7c4d049 Merge pull request #112 from mktu/develop
+349cf2a docs: update SESSION.md for session handoff
 896f853 docs: 認証フローの記述を実装と整合させ、未使用の ensure-user API を削除
 c489abd docs: update SESSION.md and ARCHITECTURE.md for session handoff
-2835285 Merge pull request #107 from mktu/feature/fix-idor-line-token-101
-f9e2be5 fix: API の lineUserId を ID トークンで検証し IDOR を防ぐ (Issue #101)
-7084e73 docs: update SESSION.md for session handoff
+00cb18c Merge pull request #108 from mktu/develop
 ```
 
 ## GitHubリポジトリ

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,7 +102,7 @@ recipe-app/
 │   │   ├── embedding/        # ベクトル埋め込み
 │   │   ├── line/             # LINE Bot・Flex Message
 │   │   ├── recipe/           # レシピ処理ロジック
-│   │   └── scraper/          # JSON-LD・__NEXT_DATA__ スクレイパー
+│   │   └── scraper/          # JSON-LD・__NEXT_DATA__・OGP スクレイパー
 │   └── types/                # 型定義
 ├── supabase/
 │   ├── functions/            # Edge Functions (Deno)
@@ -228,7 +228,7 @@ graph TB
 | `/api/recipes` | POST | IDトークン | レシピ作成 |
 | `/api/recipes/[id]` | GET/PATCH/DELETE | IDトークン | レシピ詳細取得・更新（メモ）・削除 |
 | `/api/recipes/list` | POST | IDトークン | 一覧取得（Edge Function経由） |
-| `/api/recipes/parse` | POST | IDトークン | URL解析（JSON-LD / __NEXT_DATA__） |
+| `/api/recipes/parse` | POST | IDトークン | URL解析（JSON-LD / __NEXT_DATA__ / OGP） |
 | `/api/track/recipe/[id]` | GET/POST | POSTのみIDトークン | 閲覧記録（GET: LINE用リダイレクト・認証不要、POST: LIFF用） |
 | `/api/webhook/line` | POST | LINE署名検証 | LINE Webhook（`validateSignature`） |
 
@@ -467,9 +467,13 @@ graph TB
     Strategy1 -->|Fail| Strategy2{"__NEXT_DATA__ extract"}
 
     Strategy2 -->|Success| Result
-    Strategy2 -->|Fail| Empty["Empty Result（手動入力）"]
+    Strategy2 -->|Fail| Strategy3{"OGP extract（title/image/site_name）"}
+
+    Strategy3 -->|Success| OgpResult["Parse Result（食材なし・手動入力）"]
+    Strategy3 -->|Fail| Empty["Empty Result（手動入力）"]
 
     Result --> Match["Ingredient Matching"]
+    OgpResult --> Confirm
     Empty --> Confirm
     Match --> Confirm["ユーザー確認\n(/recipes/add/confirm)"]
     Confirm --> Save["Save to DB\n(POST /api/recipes)"]

--- a/src/lib/recipe/parse-recipe.ts
+++ b/src/lib/recipe/parse-recipe.ts
@@ -3,6 +3,7 @@ import type { JsonLdExtraction } from '@/types/json-ld'
 import { fetchHtml, HtmlFetchError } from '@/lib/scraper/html-fetcher'
 import { extractRecipeFromJsonLd } from '@/lib/scraper/json-ld-extractor'
 import { extractRecipeFromNextData } from '@/lib/scraper/next-data-extractor'
+import { extractOgp } from '@/lib/scraper/ogp-extractor'
 import { matchIngredients } from './match-ingredients'
 
 /**
@@ -73,6 +74,22 @@ async function parseWithHtmlFetch(url: string): Promise<ParsedRecipe | null> {
       return buildParsedRecipe(nextDataExtraction)
     }
 
+    // Strategy 3: OGP (構造化データが無いサイトの最終フォールバック)
+    // タイトル・画像・サイト名のみ取得し、食材はユーザーが手動入力する
+    const ogpExtraction = extractOgp(html, url)
+    if (ogpExtraction) {
+      console.log('Extracted title from OGP')
+      return {
+        title: ogpExtraction.title,
+        sourceName: ogpExtraction.sourceName,
+        imageUrl: ogpExtraction.imageUrl,
+        ingredientIds: [],
+        ingredientsRaw: [],
+        memo: '',
+        cookingTimeMinutes: null,
+      }
+    }
+
     console.log('No structured data found')
     return null
   } catch (error) {
@@ -91,8 +108,9 @@ async function parseWithHtmlFetch(url: string): Promise<ParsedRecipe | null> {
  * 処理フロー:
  * 1. HTML直接取得でJSON-LD抽出を試みる
  * 2. 失敗したら__NEXT_DATA__抽出を試みる（Nadia等）
- * 3. 取得できない場合は空の結果を返す（ユーザーが手動入力）
- * 4. 食材名をingredients/ingredient_aliasesで正規化
+ * 3. それも失敗したらOGPからタイトル・画像・サイト名を取得（食材は手動入力）
+ * 4. いずれも取得できない場合は空の結果を返す（ユーザーが手動入力）
+ * 5. 食材名をingredients/ingredient_aliasesで正規化
  */
 export async function parseRecipe(url: string): Promise<ParsedRecipe> {
   try {

--- a/src/lib/scraper/ogp-extractor.test.ts
+++ b/src/lib/scraper/ogp-extractor.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { extractOgp } from './ogp-extractor'
+
+const URL = 'https://www.example.com/recipes/123'
+
+describe('extractOgp', () => {
+  it('og:title / og:image / og:site_name を抽出する', () => {
+    const html = `
+      <html><head>
+        <meta property="og:title" content="鶏の唐揚げ" />
+        <meta property="og:image" content="https://img.example.com/1.jpg" />
+        <meta property="og:site_name" content="クッキングサイト" />
+      </head></html>`
+    expect(extractOgp(html, URL)).toEqual({
+      title: '鶏の唐揚げ',
+      imageUrl: 'https://img.example.com/1.jpg',
+      sourceName: 'クッキングサイト',
+    })
+  })
+
+  it('content が property より前にあっても抽出する', () => {
+    const html = `<meta content="肉じゃが" property="og:title">`
+    expect(extractOgp(html, URL)?.title).toBe('肉じゃが')
+  })
+
+  it('og:title が無ければ <title> タグにフォールバックする', () => {
+    const html = `<html><head><title>カレーライス | レシピ</title></head></html>`
+    expect(extractOgp(html, URL)?.title).toBe('カレーライス | レシピ')
+  })
+
+  it('og:site_name が無ければURLのドメイン名をソース名にする', () => {
+    const html = `<meta property="og:title" content="味噌汁">`
+    expect(extractOgp(html, URL)?.sourceName).toBe('Example')
+  })
+
+  it('HTMLエンティティをデコードする', () => {
+    const html = `<meta property="og:title" content="塩&amp;こしょう炒め">`
+    expect(extractOgp(html, URL)?.title).toBe('塩&こしょう炒め')
+  })
+
+  it('name 属性の og:title も拾う', () => {
+    const html = `<meta name="og:title" content="親子丼">`
+    expect(extractOgp(html, URL)?.title).toBe('親子丼')
+  })
+
+  it('タイトルが取得できなければ null を返す', () => {
+    const html = `<html><head></head><body>no meta</body></html>`
+    expect(extractOgp(html, URL)).toBeNull()
+  })
+
+  it('画像が無ければ imageUrl は空文字', () => {
+    const html = `<meta property="og:title" content="冷奴">`
+    expect(extractOgp(html, URL)?.imageUrl).toBe('')
+  })
+})

--- a/src/lib/scraper/ogp-extractor.ts
+++ b/src/lib/scraper/ogp-extractor.ts
@@ -1,0 +1,87 @@
+/**
+ * OGP (Open Graph Protocol) 抽出
+ *
+ * JSON-LD・__NEXT_DATA__ で構造化レシピデータが取れなかった場合の
+ * 最終フォールバック。最低限タイトル・画像・サイト名を取得し、
+ * 食材はユーザーが手動入力する想定。
+ */
+
+/**
+ * OGPから抽出したメタ情報（食材は含まない）
+ */
+export interface OgpExtraction {
+  title: string
+  imageUrl: string
+  sourceName: string
+}
+
+/**
+ * URLからドメイン名を抽出してサイト名として使用
+ */
+function extractDomainName(url: string): string {
+  try {
+    const hostname = new URL(url).hostname
+    const domain = hostname.replace(/^www\./, '')
+    const name = domain.split('.')[0]
+    return name.charAt(0).toUpperCase() + name.slice(1)
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * HTMLエンティティをデコード（よく使われるものに限定）
+ */
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+}
+
+/**
+ * <meta property="og:xxx"> または <meta name="og:xxx"> の content を抽出
+ * property/name の前後どちらに content があっても拾えるようにする
+ */
+function extractMetaContent(html: string, property: string): string {
+  const escaped = property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  // content が property より後ろにあるパターン
+  const after = new RegExp(
+    `<meta[^>]*(?:property|name)=["']${escaped}["'][^>]*content=["']([^"']*)["']`,
+    'i'
+  )
+  // content が property より前にあるパターン
+  const before = new RegExp(
+    `<meta[^>]*content=["']([^"']*)["'][^>]*(?:property|name)=["']${escaped}["']`,
+    'i'
+  )
+  const match = after.exec(html) ?? before.exec(html)
+  return match?.[1] ? decodeHtmlEntities(match[1]).trim() : ''
+}
+
+/**
+ * <title> タグからタイトルを抽出（og:title が無い場合のフォールバック）
+ */
+function extractTitleTag(html: string): string {
+  const match = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)
+  return match?.[1] ? decodeHtmlEntities(match[1]).trim() : ''
+}
+
+/**
+ * HTMLからOGP情報を抽出
+ * @returns タイトルが取得できれば抽出結果、取れなければnull
+ */
+export function extractOgp(html: string, sourceUrl: string): OgpExtraction | null {
+  const title = extractMetaContent(html, 'og:title') || extractTitleTag(html)
+  if (!title) return null
+
+  const imageUrl = extractMetaContent(html, 'og:image')
+  const sourceName =
+    extractMetaContent(html, 'og:site_name') || extractDomainName(sourceUrl)
+
+  return { title, imageUrl, sourceName }
+}


### PR DESCRIPTION
## Summary

- 構造化データ（JSON-LD / `__NEXT_DATA__`）を持たないサイトでタイトルが取れず「タイトル未取得」で保存されていた問題を解消
- 解析の最終フォールバックとして **Strategy 3: OGP 抽出** を追加
  - `og:title` / `og:image` / `og:site_name` を抽出
  - `og:title` 無しは `<title>` タグ、`og:site_name` 無しはドメイン名にフォールバック
  - `content` が属性の前後どちらにあっても拾い、HTML エンティティもデコード
- OGP でタイトルが取れた場合は食材空（ユーザーが手動入力）の `ParsedRecipe` を返す
- `docs/ARCHITECTURE.md` の解析フロー図・ディレクトリ説明・API 表を更新
- `ogp-extractor.test.ts` に 8 ケースのユニットテストを追加

## Test plan

- [x] `npx vitest run src/lib/scraper/ogp-extractor.test.ts`（8件パス）
- [x] `npm run lint`
- [x] `npm run build`
- [ ] staging で構造化データの無いページ（個人ブログ等）の URL を LINE 送信し、タイトル・画像が取得されることを確認

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)