### PR TITLE
docs: 法的ページに運営者情報・問い合わせ窓口（メール）を明記 (#119)

### DIFF
--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function PrivacyPolicyPage() {
   return (
-    <LegalPageLayout title="プライバシーポリシー" lastUpdated="2025年2月8日">
+    <LegalPageLayout title="プライバシーポリシー" lastUpdated="2026年6月26日">
       <PrivacyContent />
     </LegalPageLayout>
   )

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function TermsOfServicePage() {
   return (
-    <LegalPageLayout title="利用規約" lastUpdated="2025年2月8日">
+    <LegalPageLayout title="利用規約" lastUpdated="2026年6月26日">
       <TermsContent />
     </LegalPageLayout>
   )

--- a/src/components/features/legal/privacy-content.tsx
+++ b/src/components/features/legal/privacy-content.tsx
@@ -107,8 +107,17 @@ function DataManagementSection() {
       <Section title="8. お問い合わせ">
         <p>
           本プライバシーポリシーに関するお問い合わせは、
-          LINE公式アカウントのトーク画面からご連絡ください。
+          以下の窓口までご連絡ください。
         </p>
+        <ul className="ml-4 list-disc space-y-1">
+          <li>運営者: RecipeHub 運営者</li>
+          <li>
+            連絡先:{' '}
+            <a href="mailto:mushi9ui@gmail.com" className="underline">
+              mushi9ui@gmail.com
+            </a>
+          </li>
+        </ul>
       </Section>
     </>
   )

--- a/src/components/features/legal/terms-content.tsx
+++ b/src/components/features/legal/terms-content.tsx
@@ -25,6 +25,7 @@ export function TermsContent() {
       <ProhibitedActionsSection />
       <ServiceProvisionSection />
       <DisclaimerSection />
+      <ContactSection />
     </>
   )
 }
@@ -140,5 +141,22 @@ function DisclaimerSection() {
         </p>
       </Section>
     </>
+  )
+}
+
+function ContactSection() {
+  return (
+    <Section title="第11条（運営者・お問い合わせ）">
+      <p>本サービスの運営者および連絡先は以下のとおりです。</p>
+      <ul className="ml-4 list-disc space-y-1">
+        <li>運営者: RecipeHub 運営者</li>
+        <li>
+          連絡先:{' '}
+          <a href="mailto:mushi9ui@gmail.com" className="underline">
+            mushi9ui@gmail.com
+          </a>
+        </li>
+      </ul>
+    </Section>
   )
 }


### PR DESCRIPTION
## 概要

法的リスクチェックで検出した、運営者情報・問い合わせ窓口の不備を解消する（#119）。

## 変更内容

### 利用規約（`terms-content.tsx`）
- **第11条（運営者・お問い合わせ）を新設** — 運営者および連絡先メールを明記
  - 運営者: RecipeHub 運営者
  - 連絡先: mushi9ui@gmail.com

### プライバシーポリシー（`privacy-content.tsx`）
- **第8条 お問い合わせ** — 窓口を LINE トーク画面からメールに変更し、運営者・連絡先を明記

### その他
- 両ページの最終更新日を 2026年6月26日 に更新

## 窓口をメールにした理由

LINE トーク画面はレシピ URL 送信・検索入力に使われており、問い合わせ窓口を兼ねると：
- 問い合わせ本文がキーワード/URL に該当せず **検索クエリ扱い**になり、「該当するレシピが見つかりませんでした」と自動返信される（`webhook/line/route.ts` → `handleSearch`）
- 用途が混在してユーザー・運営者ともに分かりにくい

ため、問い合わせはメールに分離し、レシピ操作（LINE）と窓口（メール）を明確に分けた。

## 確認

- [x] `npm run lint`

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)