### PR TITLE
feat: スクレイピングに同一ホスト最小間隔ガードと説明的UAを追加 (#120)

### DIFF
--- a/src/lib/scraper/html-fetcher.ts
+++ b/src/lib/scraper/html-fetcher.ts
@@ -5,6 +5,44 @@
 
 const TIMEOUT_MS = 15000
 
+/** 同一ホストへの連続アクセスに設ける最小間隔（ミリ秒） */
+const MIN_HOST_INTERVAL_MS = 1000
+
+/**
+ * ホストごとの「次にアクセス可能になる時刻」を保持する。
+ * 取得はユーザー起点・単発のため厳密な分散レート制限は行わず、
+ * 同一インスタンス内での同一ホスト連打を緩やかに抑える礼儀的なガード。
+ * （serverless ではインスタンス間で状態は共有されない点に留意）
+ */
+const nextAllowedFetchByHost = new Map<string, number>()
+
+/**
+ * 同一ホストへのアクセスが最小間隔を下回る場合、必要な分だけ待機する。
+ * 並行リクエストはスロットを予約することで順番に処理される。
+ */
+async function throttleHost(host: string): Promise<void> {
+  const now = Date.now()
+  const scheduled = Math.max(now, nextAllowedFetchByHost.get(host) ?? 0)
+  nextAllowedFetchByHost.set(host, scheduled + MIN_HOST_INTERVAL_MS)
+  const waitMs = scheduled - now
+  if (waitMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, waitMs))
+  }
+}
+
+/** 連絡先（問い合わせ窓口）。サイト運営者が識別・連絡できるよう UA に含める */
+const CONTACT_EMAIL = 'mushi9ui@gmail.com'
+
+/**
+ * 説明的な User-Agent を構築する。
+ * 用途（ユーザー起点のレシピメタデータ取得）と連絡先を明示し、
+ * 取得元サイトが識別・問い合わせできるようにする（検出回避はしない）。
+ */
+function buildUserAgent(): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://github.com/mktu/recipe-app'
+  return `RecipeHub-Bot/1.0 (+${appUrl}; user-requested recipe metadata fetch; contact: ${CONTACT_EMAIL})`
+}
+
 export interface HtmlFetchResult {
   html: string
   contentType: string
@@ -25,6 +63,12 @@ export class HtmlFetchError extends Error {
  * URLからHTMLを直接取得する
  */
 export async function fetchHtml(url: string): Promise<HtmlFetchResult> {
+  try {
+    await throttleHost(new URL(url).hostname)
+  } catch {
+    // URL が不正な場合はスロットリングをスキップ（後続の fetch でエラーになる）
+  }
+
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS)
 
@@ -32,7 +76,7 @@ export async function fetchHtml(url: string): Promise<HtmlFetchResult> {
     const response = await fetch(url, {
       signal: controller.signal,
       headers: {
-        'User-Agent': `RecipeHub-Bot/1.0 (+${process.env.NEXT_PUBLIC_APP_URL || 'https://github.com/mktu/recipe-app'})`,
+        'User-Agent': buildUserAgent(),
         Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
         'Accept-Language': 'ja,en;q=0.9',
       },

--- a/src/lib/scraper/html-fetcher.ts
+++ b/src/lib/scraper/html-fetcher.ts
@@ -30,17 +30,15 @@ async function throttleHost(host: string): Promise<void> {
   }
 }
 
-/** 連絡先（問い合わせ窓口）。サイト運営者が識別・連絡できるよう UA に含める */
-const CONTACT_EMAIL = 'mushi9ui@gmail.com'
-
 /**
  * 説明的な User-Agent を構築する。
- * 用途（ユーザー起点のレシピメタデータ取得）と連絡先を明示し、
+ * 用途（ユーザー起点のレシピメタデータ取得）と情報URLを明示し、
  * 取得元サイトが識別・問い合わせできるようにする（検出回避はしない）。
+ * 連絡先は URL 先からたどれるため、UA に生のメールアドレスは含めない。
  */
 function buildUserAgent(): string {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://github.com/mktu/recipe-app'
-  return `RecipeHub-Bot/1.0 (+${appUrl}; user-requested recipe metadata fetch; contact: ${CONTACT_EMAIL})`
+  return `RecipeHub-Bot/1.0 (+${appUrl}; user-requested recipe metadata fetch)`
 }
 
 export interface HtmlFetchResult {


### PR DESCRIPTION
## 概要

法的リスクチェックで検出した低優先項目（#120）への対応。スクレイピングのレートリミットと User-Agent 命名を見直す。

取得は **ユーザー起点・1リクエスト1URL** のため元々低リスクだが、礼儀（politeness）と透明性を高める。

## 変更内容（`src/lib/scraper/html-fetcher.ts`）

### 1. 同一ホストへの最小間隔ガード
- モジュール内 Map で同一ホストへの連続アクセスに **最小間隔1秒** を設ける
- 並行リクエストはスロット予約で順番に処理
- ⚠️ serverless ではインスタンス間で状態共有されないため厳密な分散制限ではない（コメントに明記）。ユーザー起点・単発という前提に見合った軽量ガード

### 2. 説明的な User-Agent
- before: `RecipeHub-Bot/1.0 (+<appUrl>)`
- after: `RecipeHub-Bot/1.0 (+<appUrl>; user-requested recipe metadata fetch)`
- **「Bot」は残し**、用途と情報URLを明示。サイト運営者が識別・問い合わせできるようにする（検出回避はしない方針）
- 連絡先は情報URL先からたどれるため、全取得先サイトのログに残る**生のメールアドレスは UA に含めない**（bot UA の慣習＝URL明示に揃える）

## 確認

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`（24 tests passed）

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)