### PR TITLE
docs: プライバシーポリシーの収集情報を実態に合わせて追記

### DIFF
--- a/src/components/features/legal/privacy-content.tsx
+++ b/src/components/features/legal/privacy-content.tsx
@@ -14,7 +14,11 @@ export function PrivacyContent() {
         <ul className="ml-4 list-disc space-y-1">
           <li>LINEアカウント情報（ユーザーID、表示名）</li>
           <li>ユーザーが登録したレシピURL</li>
+          <li>
+            登録URLから取得したレシピのメタデータ（タイトル、サイト名、画像URL、調理時間等）
+          </li>
           <li>レシピに関連する食材タグ、メモ等の情報</li>
+          <li>レシピの閲覧回数・最終閲覧日時等の利用状況</li>
           <li>サービス利用に関するログ情報</li>
         </ul>
       </Section>


### PR DESCRIPTION
## 概要

法的リスクチェックの結果、プライバシーポリシーの「収集する情報」に、実装で実際に保存している項目の一部が記載されていなかったため追記する。

## 背景

`/legal-check` で実装とポリシーを突き合わせたところ、以下が「収集する情報」に未記載だった:

- 登録URLから取得したレシピのメタデータ（タイトル・サイト名・画像URL・調理時間）
- 閲覧履歴（`recipes.view_count` / `last_viewed_at`）

虚偽ではなく不足であり咎められる可能性は低いが、実態と記載を一致させておく軽微な修正。

## 変更内容

`src/components/features/legal/privacy-content.tsx` の「1. 収集する情報」に2項目を追記。

- 登録URLから取得したレシピのメタデータ（タイトル、サイト名、画像URL、調理時間等）
- レシピの閲覧回数・最終閲覧日時等の利用状況

## 確認

- [x] `npm run lint` パス

## 補足（本PR対象外・別途検討）

法的チェックで挙がった他の項目:
- RLS 未実効（Issue #110）— セキュリティ実害の芽として優先度高
- Gemini API のティアと学習利用の整合確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)