### PR TITLE
fix: レシピ再取得時にタイトル等のメタ情報を上書き保存

### DIFF
--- a/src/app/api/recipes/[id]/route.ts
+++ b/src/app/api/recipes/[id]/route.ts
@@ -66,6 +66,10 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   if (body.ingredientIds) updates.ingredientIds = body.ingredientIds
   if (body.ingredientsRaw) updates.ingredientsRaw = body.ingredientsRaw
   if (typeof body.memo === 'string') updates.memo = body.memo
+  if (typeof body.title === 'string') updates.title = body.title
+  if (typeof body.sourceName === 'string') updates.sourceName = body.sourceName
+  if (typeof body.imageUrl === 'string') updates.imageUrl = body.imageUrl
+  if (body.cookingTimeMinutes !== undefined) updates.cookingTimeMinutes = body.cookingTimeMinutes
 
   const { error } = await updateRecipe(lineUserId, id, updates)
   if (error) {

--- a/src/components/features/recipe-detail/rescrape-dialog.tsx
+++ b/src/components/features/recipe-detail/rescrape-dialog.tsx
@@ -17,13 +17,29 @@ interface RescrapeDialogProps {
   onSaved: () => void
 }
 
-function RescrapePreview({ imageUrl, ingredientsRaw }: { imageUrl: string; ingredientsRaw: IngredientRaw[] }) {
+function RescrapePreview({
+  title,
+  sourceName,
+  imageUrl,
+  ingredientsRaw,
+}: {
+  title: string
+  sourceName: string
+  imageUrl: string
+  ingredientsRaw: IngredientRaw[]
+}) {
   return (
     <div className="space-y-4">
       {imageUrl && (
         <div className="aspect-video w-full overflow-hidden rounded-lg bg-muted">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={imageUrl} alt="レシピ画像" className="h-full w-full object-cover" />
+        </div>
+      )}
+      {title && (
+        <div>
+          <p className="text-sm font-medium">{title}</p>
+          {sourceName && <p className="text-xs text-muted-foreground">{sourceName}</p>}
         </div>
       )}
       {ingredientsRaw.length > 0 && (
@@ -43,6 +59,26 @@ function RescrapePreview({ imageUrl, ingredientsRaw }: { imageUrl: string; ingre
   )
 }
 
+function IngredientSection({
+  categories,
+  selectedIds,
+  onSelectionChange,
+}: {
+  categories: IngredientsByCategory[]
+  selectedIds: string[]
+  onSelectionChange: (ids: string[]) => void
+}) {
+  return (
+    <section className="space-y-3">
+      <p className="text-sm font-medium">メイン食材</p>
+      <p className="text-xs text-muted-foreground">食材検索で使われるタグです。</p>
+      {categories.length > 0 && (
+        <IngredientSelector categories={categories} selectedIds={selectedIds} onSelectionChange={onSelectionChange} />
+      )}
+    </section>
+  )
+}
+
 export function RescrapeDialog({ recipe, parsed, open, onOpenChange, onSaved }: RescrapeDialogProps) {
   const { updateRecipe, isLoading: isSaving, error: saveError } = useUpdateRecipe(recipe.id)
   const [categories, setCategories] = useState<IngredientsByCategory[]>([])
@@ -56,12 +92,16 @@ export function RescrapeDialog({ recipe, parsed, open, onOpenChange, onSaved }: 
     const success = await updateRecipe({
       ingredientIds,
       ingredientsRaw: parsed.ingredientsRaw,
+      title: parsed.title,
+      sourceName: parsed.sourceName,
+      imageUrl: parsed.imageUrl,
+      cookingTimeMinutes: parsed.cookingTimeMinutes,
     })
     if (success) {
       onOpenChange(false)
       onSaved()
     }
-  }, [updateRecipe, ingredientIds, parsed.ingredientsRaw, onOpenChange, onSaved])
+  }, [updateRecipe, ingredientIds, parsed, onOpenChange, onSaved])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -70,14 +110,13 @@ export function RescrapeDialog({ recipe, parsed, open, onOpenChange, onSaved }: 
           <DialogTitle>レシピ情報の再取得結果</DialogTitle>
         </DialogHeader>
         <div className="space-y-6">
-          <RescrapePreview imageUrl={parsed.imageUrl} ingredientsRaw={parsed.ingredientsRaw ?? []} />
-          <section className="space-y-3">
-            <p className="text-sm font-medium">メイン食材</p>
-            <p className="text-xs text-muted-foreground">食材検索で使われるタグです。</p>
-            {categories.length > 0 && (
-              <IngredientSelector categories={categories} selectedIds={ingredientIds} onSelectionChange={setIngredientIds} />
-            )}
-          </section>
+          <RescrapePreview
+            title={parsed.title}
+            sourceName={parsed.sourceName}
+            imageUrl={parsed.imageUrl}
+            ingredientsRaw={parsed.ingredientsRaw ?? []}
+          />
+          <IngredientSection categories={categories} selectedIds={ingredientIds} onSelectionChange={setIngredientIds} />
           {saveError && (
             <div className="rounded-lg border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
               {saveError.message}

--- a/src/lib/db/queries/recipe-detail.ts
+++ b/src/lib/db/queries/recipe-detail.ts
@@ -120,7 +120,22 @@ async function replaceRecipeIngredients(client: TypedSupabaseClient, recipeId: s
   if (error) throw error
 }
 
-/** レシピを更新（食材・メモ等） */
+/** UpdateRecipeInput を recipes テーブルの更新用カラムにマッピング */
+function buildRecipeUpdate(updates: UpdateRecipeInput): TablesInsert<'recipes'> & { updated_at: string } {
+  const recipeUpdate: TablesInsert<'recipes'> & { updated_at: string } = {
+    updated_at: new Date().toISOString(),
+  } as TablesInsert<'recipes'> & { updated_at: string }
+  if (typeof updates.memo === 'string') recipeUpdate.memo = updates.memo
+  if (updates.ingredientsRaw) recipeUpdate.ingredients_raw = updates.ingredientsRaw as unknown as Json
+  if (updates.ingredientIds) recipeUpdate.ingredients_linked = updates.ingredientIds.length > 0
+  if (typeof updates.title === 'string') recipeUpdate.title = updates.title
+  if (typeof updates.sourceName === 'string') recipeUpdate.source_name = updates.sourceName || null
+  if (typeof updates.imageUrl === 'string') recipeUpdate.image_url = updates.imageUrl || null
+  if (updates.cookingTimeMinutes !== undefined) recipeUpdate.cooking_time_minutes = updates.cookingTimeMinutes
+  return recipeUpdate
+}
+
+/** レシピを更新（食材・メモ・メタ情報等） */
 export async function updateRecipe(
   lineUserId: string,
   recipeId: string,
@@ -132,12 +147,7 @@ export async function updateRecipe(
     const userId = await getUserIdByLineUserId(client, lineUserId)
     if (!userId) return { error: new Error('ユーザーが見つかりません') }
 
-    const recipeUpdate: TablesInsert<'recipes'> & { updated_at: string } = {
-      updated_at: new Date().toISOString(),
-    } as TablesInsert<'recipes'> & { updated_at: string }
-    if (typeof updates.memo === 'string') recipeUpdate.memo = updates.memo
-    if (updates.ingredientsRaw) recipeUpdate.ingredients_raw = updates.ingredientsRaw as unknown as Json
-    if (updates.ingredientIds) recipeUpdate.ingredients_linked = updates.ingredientIds.length > 0
+    const recipeUpdate = buildRecipeUpdate(updates)
 
     const { error: updateError } = await client
       .from('recipes')

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -70,6 +70,10 @@ export interface UpdateRecipeInput {
   ingredientIds?: string[]
   ingredientsRaw?: IngredientRaw[]
   memo?: string
+  title?: string
+  sourceName?: string
+  imageUrl?: string
+  cookingTimeMinutes?: number | null
 }
 
 /** レシピ詳細（詳細画面用） */


### PR DESCRIPTION
## Summary

- 「レシピ情報を再度取得」で取得した title / source_name / image_url / cooking_time_minutes が DB に反映されないバグを修正
- 再取得フローは材料・メモのみ更新しており、スクレイパーが取得したメタ情報を保存していなかった（初回登録 `insertRecipe` は全項目保存しており非対称だった）
- `UpdateRecipeInput` 型と `updateRecipe()` にメタ情報フィールドを追加し、再取得ダイアログから全項目を送信して上書き保存
- 再取得ダイアログのプレビューに取得タイトル・サイト名を表示
- complexity / max-lines 警告を解消（`buildRecipeUpdate` / `IngredientSection` を分離）

## Test plan

- [ ] レシピ詳細から「レシピ情報を再度取得」を実行
- [ ] プレビューに取得したタイトル・画像・サイト名が表示される
- [ ] 「保存」後、レシピのタイトル・画像・サイト名・調理時間が新しい値で上書きされている
- [ ] 材料・メモが従来通り更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)