### PR TITLE
docs: スクレイピング方針を明文化 (SCRAPING_POLICY.md)

### DIFF
--- a/SESSION.md
+++ b/SESSION.md
@@ -1,12 +1,28 @@
 # セッション引き継ぎ
 
 ## 最終更新
-2026-06-16 (#111 README を RecipeHub 用に整備し PR #116 を develop にマージ)
+2026-07-03 (#110 RLS ポリシー整理を PR #126 で develop→main まで反映。/legal-check 実施)
 
 ## 現在のフェーズ
 フェーズ 3：LINE Messaging API 連携 - **本番稼働中**
 
 ## 直近の完了タスク
+- [x] **#110 RLS ポリシーを実アーキテクチャに沿って整理・明示化（PR #126→develop→main反映済み・merged 2026-07-03）**
+  - `/legal-check` の要対応「RLS 未実効」への対応。全面的な per-user RLS（Supabase Auth 導入=option a）ではなく、**Issue #110 推奨の費用対効果の高い路線**（空振りポリシー整理・意図明示・回帰テスト）を採用
+  - 調査で判明: LINE 認証で Supabase Auth ユーザー不在のため init の `auth.uid()` ベースポリシーは**誰にもマッチしない空振り（dead code）**。per-user 認可に見えて実は機能していなかった。ブラウザ(anon)が触るのは公開マスター `ingredients` のみ、ユーザーデータは全て service_role でサーバー経由
+  - 新マイグレーション `20260702000000_clarify_rls_policies.sql`: `users`/`recipes`/`recipe_ingredients` は空振りポリシー撤去→`service_role` フルアクセスのみ（anon は既定拒否）。`ingredients`/`ingredient_aliases` は公開 SELECT 維持+service_role 書込。service_role は BYPASSRLS のため**実行時挙動は不変**（意図明示と dead code 排除が目的）
+  - デッドコード削除: ブラウザ露出 anon で `recipes` を引く `src/lib/db/queries/recipe-search.ts`（+re-export）。呼び出しは全て `/api/recipes/list`→Edge Function `get-recipes`(service_role) 経由で未使用と確認
+  - 回帰テスト: `test-migrations.yml` に anon がユーザーデータを読めないことを検証するステップ追加。**環境差の学び**: ローカル/Cloud は blanket GRANT ありで RLS 層(0件)拒否、CI はクリーンで GRANT 層(permission denied)拒否 → 両方を「拒否＝合格」として扱う。公開マスターは実行時読取(GRANT依存)でなく public SELECT ポリシー存在で検証
+  - `docs/ARCHITECTURE.md` の RLS 記述を実態に更新
+  - **スコープ外（将来）:** Supabase Auth 導入による真の per-user DB 分離(option a)は Issue でも「今すぐ必須でない」→ ブラウザから Supabase を直接叩く設計に変える場合に再検討
+  - lint / test(24) / build / ローカル RLS 挙動検証・CI 全パス
+- [x] **/legal-check（法的リスクチェック）を実施（2026-07-03）**
+  - 著作権面（本文非保存・画像URL参照）とアカウント削除フロー（deauthorize+CASCADE）は堅実、外部4サービスもポリシー記載済みで良好
+  - 要対応: ①RLS 未実効（#110→上記で対応済み）②プライバシーポリシーの収集項目取りこぼし（→下記 PR #124 で対応済み）
+  - 要確認（人間判断）: Gemini API ティアと学習利用の整合（#102 で開示済み）、運営者匿名表示の是非
+- [x] **プライバシーポリシーの収集情報にレシピメタデータ・閲覧履歴を追記（PR #124→develop反映済み・merged 2026-07-01）**
+  - `/legal-check` で発見: 実装で保存している「レシピのメタデータ（タイトル/サイト名/画像URL/調理時間）」と「閲覧履歴（view_count/last_viewed_at）」が `privacy-content.tsx` の「1. 収集する情報」に未記載
+  - 虚偽ではなく不足のため軽微だが実態と一致させる修正。lint パス確認済み
 - [x] **#111 README を RecipeHub 用に整備（PR #116→develop反映済み・merged 2026-06-16）**
   - 課題: README が `create-next-app` デフォルトのまま（36行）。アプリ公開・技術記事化（#109）に向けて概要が伝わる README に刷新
   - 概要・ビジョン・主な機能・技術スタック・セットアップ・ドキュメント導線・法的事項を記載
@@ -96,8 +112,6 @@
 - [ ] **#37〜#39: E2E テスト**
 - [ ] **#106 API コールを lib/api の typed 関数レイヤーに集約（リファクタ・保守性）**
   - パス直書き・`res.ok` エラー定型の重複を解消。`useApiXxx` ではなく素の関数 + `request()` ヘルパー
-- [ ] **#110 RLS の実効化（defense-in-depth・優先度中〜低）**
-  - 現状 `auth.uid()` ベースのポリシーは Supabase Auth 不在で空振り。先に単一データアクセス層・クロスユーザーテストが費用対効果高
 
 ## ブロッカー・注意点
 - **PR は必ず `--base develop` を指定する**（`/create-pr` スキルを使うと安全）
@@ -123,6 +137,8 @@
 - `src/lib/scraper/ogp-extractor.ts` - OGP 抽出（タイトルフォールバック）
 - `src/components/features/legal/privacy-content.tsx` - プライバシーポリシー
 - `src/components/features/legal/terms-content.tsx` - 利用規約
+- `supabase/migrations/20260702000000_clarify_rls_policies.sql` - RLS ポリシー（service_role ベース・設計意図をコメント記載）
+- `.github/workflows/test-migrations.yml` - マイグレーションテスト（RLS backstop 回帰テスト含む）
 - `src/lib/auth/verify-line-token.ts` - ID トークン検証（dev バイパス）
 - `src/lib/api/auth-guard.ts` - `requireLineUser()`（API 認証ガード）
 - `src/hooks/use-authed-fetch.ts` - `useAuthedFetch`（Authorization ヘッダ自動付与）
@@ -133,11 +149,11 @@
 
 ## コミット履歴（直近）
 ```
-8253726 Merge pull request #116 from mktu/feature/docs-readme-recipehub-111
-1ba10f0 docs: README の環境変数・ディレクトリ構成を各ドキュメント参照に変更 (#111)
-38c5e3d docs: requirements.md 冒頭に実装との乖離注記を追加 (#111)
-687f935 docs: レシピのタグ付けを「AI」から実態（構造化データ抽出）へ修正 (#111)
-eb5c8ac docs: ビジョン文言を「献立選びをもっとラクに」へ統一 (#111)
+4ea8038 Merge pull request #126 from mktu/feature/refactor-rls-clarify-policies
+59bd519 fix(ci): RLS 回帰テストを GRANT 拒否と RLS 0件の両方に対応
+b2c28da refactor: RLS ポリシーを実アーキテクチャに沿って整理・明示化 (#110)
+a588e0c Merge pull request #124 from mktu/feature/docs-privacy-collection-items
+333fce5 docs: プライバシーポリシーの収集情報にレシピメタデータと閲覧履歴を追記
 ```
 
 ## GitHubリポジトリ

--- a/docs/SCRAPING_POLICY.md
+++ b/docs/SCRAPING_POLICY.md
@@ -1,0 +1,53 @@
+# スクレイピング方針
+
+本サービス（RecipeHub）が外部レシピサイトからレシピ情報を取得する際の方針を定める。
+法的リスク（著作権・サイト利用規約・robots.txt）への配慮を明文化し、実装との整合を担保する。
+
+> 実装: `src/lib/scraper/`（`html-fetcher.ts` / `json-ld-extractor.ts` / `next-data-extractor.ts` / `ogp-extractor.ts`）
+
+## 取得対象
+
+- 対象ページが**公開している構造化データ**（JSON-LD `schema.org/Recipe` / `__NEXT_DATA__` / OGP）のみを取得する。
+- 取得項目は以下のメタデータに限定する:
+  - タイトル
+  - サイト名（source name）
+  - 画像URL（**画像そのものは自サーバーに複製・保存せず、URL を参照するのみ**）
+  - 食材名（分量は保存しない。`ingredients_raw` は `amount: ''`）
+  - 調理時間
+- **調理手順・本文・レシピ写真等の創作的表現は取得・保存しない。**
+
+## アクセス様態
+
+- **ユーザーが登録操作した URL の単発取得のみ**を行う。サイト全体の巡回・クロール・全件取得はしない。
+- User-Agent は `RecipeHub-Bot/1.0 (+<APP_URL>; user-requested recipe metadata fetch)` を明示送信する。
+  - 用途と問い合わせ経路を明示し、**検出回避（UA 偽装等）は行わない**。
+- 同一ホストへのアクセスは最小 1,000ms 間隔に抑える（`html-fetcher.ts` の `throttleHost`）。
+- タイムアウトは 15 秒。
+
+## robots.txt に対するスタンス
+
+- 本サービスの取得は「ユーザー起点の単発フェッチ」であり自律巡回クローラーではないが、対象サイトの意向を尊重する。
+- **主要対象サイトのレシピ詳細ページが `User-agent: *` で許可されていることを確認済み（2026-07 時点）:**
+
+  | サイト | robots.txt のレシピ詳細ページ | 備考 |
+  |--------|------------------------------|------|
+  | Cookpad (`cookpad.com`) | 許可（`Allow: /`） | `/print` 等の一部機能パスは Disallow。`anthropic-ai` / `ClaudeBot` / `GPTBot` 等 **AI 収集系 UA は明示ブロック** |
+  | Nadia (`oceans-nadia.com`) | 許可 | `/print`・`/image_slide`・`/search` 等が Disallow |
+  | Kurashiru (`kurashiru.com`) | 許可 | `/api/` 等が Disallow。`GPTBot` は全面ブロック |
+
+- robots.txt で **Disallow に指定されたパス（`/print` 等）は取得しない。**
+- **AI 学習用途のクロールを拒否しているサイト**（Cookpad / Kurashiru 等）の扱い:
+  - 本サービスの取得は AI 学習用の巡回ではなく、ユーザー起点のメタデータ取得であるため許可範囲と解する。
+  - ただし取得後にタイトル等を Gemini へ送信するため、可能な限り Gemini は**学習に利用されない tier**（有料 / データ利用オフ）を用いる（別途 Issue で確認）。
+- robots.txt の内容は変わりうるため、**主要サイトの状況は定期的に再確認**し、本表の「確認時点」を更新する。
+
+## 対象外運用
+
+- robots.txt や利用規約で取得を明確に拒否しているサイト、取得停止の申し入れがあったサイトは対象から外す。
+- 403 / 451 を返すサイトへの取得はブロックとみなし、リトライで回避しない（`HtmlFetchError.isBlocked`）。
+
+## 関連ドキュメント
+
+- 利用規約 第5条（著作権）・第6条（レシピサイトの解析について）: `src/components/features/legal/terms-content.tsx`
+- プライバシーポリシー §1（収集する情報）・§4（外部サービスとの連携）: `src/components/features/legal/privacy-content.tsx`
+- アーキテクチャ（レシピ解析フロー）: `docs/ARCHITECTURE.md`

--- a/src/lib/scraper/html-fetcher.ts
+++ b/src/lib/scraper/html-fetcher.ts
@@ -1,6 +1,8 @@
 /**
  * HTML直接フェッチャー
  * Jina Readerを経由せずにHTMLを取得する
+ *
+ * 取得対象・アクセス様態・robots.txt に対する方針は docs/SCRAPING_POLICY.md を参照。
  */
 
 const TIMEOUT_MS = 15000


### PR DESCRIPTION
## Summary

- `docs/SCRAPING_POLICY.md` を新規作成し、外部レシピサイトからの取得方針を明文化。
- 取得対象（公開構造化データのメタデータのみ・手順/本文は非取得）、アクセス様態（ユーザー起点の単発取得・UA明示・同一ホスト1秒間隔）、robots.txt に対するスタンスを記載。
- 主要対象サイト（Cookpad / Nadia / Kurashiru）のレシピ詳細ページが `User-agent: *` で許可されていることを **2026-07 時点で確認した記録**を含む（AI 収集系 UA ブロックの注記付き）。
- `html-fetcher.ts` の先頭コメントに本方針ドキュメントへの参照を追記。

> 背景: `/legal-check` の「robots.txt 遵守方針の明文化（最低限対応）」への対応。挙動変更なし（ドキュメント＋コメントのみ）。robots.txt の自動取得・遵守（実装）は別途検討。

## Test plan

- [ ] `docs/SCRAPING_POLICY.md` の記載が実装（`src/lib/scraper/`）と整合しているか確認
- [ ] `html-fetcher.ts` の参照コメントを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)