### PR TITLE
feat: 利用規約・プライバシーポリシーへの同意導線を追加

### DIFF
--- a/src/app/api/webhook/line/route.ts
+++ b/src/app/api/webhook/line/route.ts
@@ -124,12 +124,17 @@ async function handleFollowEvent(event: webhook.Event): Promise<void> {
 
   await ensureUser(userId)
 
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || ''
   await client.pushMessage({
     to: userId,
     messages: [
       {
         type: 'text',
         text: 'RecipeHub へようこそ！🍳\n\nレシピサイトの URL をこのトークに送ると、自動でレシピを保存できます。\nクックパッド、クラシル、デリッシュキッチンなど主要サイトに対応しています。',
+      },
+      {
+        type: 'text',
+        text: `ご利用にあたっては、以下の利用規約・プライバシーポリシーをご確認ください。本サービスのご利用をもって、これらに同意いただいたものとみなします。\n\n📄 利用規約\n${appUrl}/terms\n\n🔒 プライバシーポリシー\n${appUrl}/privacy`,
       },
     ],
   })

--- a/src/components/features/lp/cta-section.tsx
+++ b/src/components/features/lp/cta-section.tsx
@@ -27,6 +27,17 @@ export function CTASection({ lineFriendUrl }: CTASectionProps) {
               LINEで友だち追加
             </Link>
           </Button>
+          <p className="mt-4 text-xs text-muted-foreground">
+            友だち追加により
+            <Link href="/terms" className="underline hover:text-foreground">
+              利用規約
+            </Link>
+            ・
+            <Link href="/privacy" className="underline hover:text-foreground">
+              プライバシーポリシー
+            </Link>
+            に同意したものとみなします。
+          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## 概要

法的リスクチェック（`/legal-check`）で判明した、公開前に対応が必要な**同意導線の欠如**を解消する。

利用規約 第2条は「LINE アカウントによるログインをもって利用登録が完了」＝利用契約成立と定めているが、登録が完了する時点（友だち追加 / LIFF ログイン）で規約が一度も提示されておらず、同意の意思表示の導線が欠けていた。規約は掲出されているものの拘束力が弱い状態だった。

## 変更内容

| # | 対応 | ファイル |
|---|------|---------|
| 1 | 友だち追加時のウェルカムメッセージに利用規約・プライバシーポリシーの URL と同意文言を追記 | `src/app/api/webhook/line/route.ts` |
| 2 | LP の CTA ボタン直下に同意文言＋規約・ポリシーへのリンクを配置 | `src/components/features/lp/cta-section.tsx` |

## 設計方針

QR コード・LINE 検索・共有リンク経由など **LP を経由しない登録経路**があるため、全ユーザーが必ず通過する**ウェルカムメッセージへの追記を主**とし、LP の CTA 補強はそれを補完する位置づけ。

## 動作確認

- [x] `npm run lint`
- [x] `npm run build`

## 補足

ウェルカムメッセージの URL は `NEXT_PUBLIC_APP_URL` を基点に `/terms`・`/privacy` を組み立てる。staging での動作確認時、当該環境変数が設定されていることを確認すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)