### PR TITLE
feat: 手動の食材紐付けに検索機能を追加（Issue #139）

### DIFF
--- a/src/components/features/add-recipe/ingredient-picker.tsx
+++ b/src/components/features/add-recipe/ingredient-picker.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { Search, X } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { IngredientList } from './ingredient-list'
+import { filterIngredientsByQuery } from '@/lib/recipe/search-ingredient'
+import type { IngredientsByCategory } from '@/types/recipe'
+
+interface IngredientPickerProps {
+  categories: IngredientsByCategory[]
+  selectedIds: string[]
+  onToggle: (id: string) => void
+  isMaxReached: boolean
+}
+
+/**
+ * メイン食材を「検索」または「カテゴリ」から選ぶピッカー
+ * 検索欄に入力があれば部分一致の検索結果、空ならカテゴリ一覧を表示する
+ */
+export function IngredientPicker({ categories, selectedIds, onToggle, isMaxReached }: IngredientPickerProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const allIngredients = useMemo(() => categories.flatMap((cat) => cat.ingredients), [categories])
+  const searchResults = useMemo(
+    () => filterIngredientsByQuery(allIngredients, searchQuery),
+    [allIngredients, searchQuery]
+  )
+
+  // 検索結果から新規に追加したら入力欄をクリアして次の食材を探しやすくする（選択解除時は維持）
+  const handleSearchToggle = useCallback(
+    (id: string) => {
+      if (!selectedIds.includes(id)) setSearchQuery('')
+      onToggle(id)
+    },
+    [selectedIds, onToggle]
+  )
+
+  return (
+    <div className="space-y-4">
+      <SearchInput value={searchQuery} onChange={setSearchQuery} />
+      {searchQuery.trim() ? (
+        <SearchResults
+          query={searchQuery}
+          ingredients={searchResults}
+          selectedIds={selectedIds}
+          onToggle={handleSearchToggle}
+          isMaxReached={isMaxReached}
+        />
+      ) : (
+        <IngredientList categories={categories} selectedIds={selectedIds} onToggle={onToggle} isMaxReached={isMaxReached} />
+      )}
+    </div>
+  )
+}
+
+function SearchInput({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="relative">
+      <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <Input placeholder="食材を検索..." value={value} onChange={(e) => onChange(e.target.value)} className="pl-9" />
+      {value && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="absolute top-1/2 right-1 h-7 w-7 -translate-y-1/2 p-0"
+          onClick={() => onChange('')}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  )
+}
+
+interface SearchResultsProps {
+  query: string
+  ingredients: { id: string; name: string }[]
+  selectedIds: string[]
+  onToggle: (id: string) => void
+  isMaxReached: boolean
+}
+
+function SearchResults({ query, ingredients, selectedIds, onToggle, isMaxReached }: SearchResultsProps) {
+  if (ingredients.length === 0) {
+    return <p className="mt-4 text-center text-sm text-muted-foreground">「{query}」に一致する食材がありません</p>
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {ingredients.map((ing) => {
+        const isSelected = selectedIds.includes(ing.id)
+        const isDisabled = !isSelected && isMaxReached
+        return (
+          <Badge
+            key={ing.id}
+            variant={isSelected ? 'default' : 'outline'}
+            className={`cursor-pointer ${isDisabled ? 'cursor-not-allowed opacity-50' : ''}`}
+            onClick={() => !isDisabled && onToggle(ing.id)}
+          >
+            {ing.name}
+            {isSelected && <X className="ml-1 h-3 w-3" />}
+          </Badge>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/features/add-recipe/ingredient-selector.tsx
+++ b/src/components/features/add-recipe/ingredient-selector.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { useSelectedIngredients } from '@/hooks/use-selected-ingredients'
-import { IngredientList } from './ingredient-list'
+import { IngredientPicker } from './ingredient-picker'
 import type { IngredientsByCategory } from '@/types/recipe'
 
 const MAX_INGREDIENTS = 5
@@ -51,8 +51,8 @@ function IngredientSheet({ open, onOpenChange, selectedCount, categories, select
         <SheetHeader>
           <SheetTitle>メイン食材を選択（{selectedCount}/{MAX_INGREDIENTS}）</SheetTitle>
         </SheetHeader>
-        <div className="mt-4 overflow-y-auto px-4 pb-4">
-          <IngredientList categories={categories} selectedIds={selectedIds} onToggle={onToggle} isMaxReached={isMaxReached} />
+        <div className="mt-4 overflow-y-auto px-4 pt-2 pb-4">
+          <IngredientPicker categories={categories} selectedIds={selectedIds} onToggle={onToggle} isMaxReached={isMaxReached} />
         </div>
       </SheetContent>
     </Sheet>

--- a/src/components/features/home/ingredient-filter-content.tsx
+++ b/src/components/features/home/ingredient-filter-content.tsx
@@ -138,7 +138,7 @@ function SearchInput({ value, onChange }: { value: string; onChange: (v: string)
   return (
     <div className="relative">
       <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-      <Input placeholder="食材を入力..." value={value} onChange={(e) => onChange(e.target.value)} className="pl-9" />
+      <Input placeholder="食材を検索..." value={value} onChange={(e) => onChange(e.target.value)} className="pl-9" />
       {value && (
         <Button
           variant="ghost"

--- a/src/hooks/use-ingredient-filter.ts
+++ b/src/hooks/use-ingredient-filter.ts
@@ -2,11 +2,7 @@
 
 import { useState, useCallback, useMemo } from 'react'
 
-/** ひらがな → カタカナ に正規化（大文字小文字も統一） */
-function toKatakana(str: string): string {
-  return str.replace(/[\u3041-\u3096]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) + 0x60))
-}
-
+import { filterIngredientsByQuery } from '@/lib/recipe/search-ingredient'
 import { useIngredientHistory } from './use-ingredient-history'
 import type { IngredientsByCategory } from '@/types/recipe'
 
@@ -27,11 +23,10 @@ export function useIngredientFilter({ categories, selectedIds, onSelectionChange
 
   const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds])
 
-  const filteredIngredients = useMemo(() => {
-    if (!searchQuery.trim()) return []
-    const query = toKatakana(searchQuery.toLowerCase())
-    return allIngredients.filter((ing) => toKatakana(ing.name.toLowerCase()).includes(query) && !selectedSet.has(ing.id))
-  }, [allIngredients, searchQuery, selectedSet])
+  const filteredIngredients = useMemo(
+    () => filterIngredientsByQuery(allIngredients, searchQuery, selectedSet),
+    [allIngredients, searchQuery, selectedSet]
+  )
 
   const validHistory = useMemo(() => {
     const idSet = new Set(allIngredients.map((i) => i.id))

--- a/src/lib/recipe/search-ingredient.test.ts
+++ b/src/lib/recipe/search-ingredient.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { toKatakana, filterIngredientsByQuery } from './search-ingredient'
+
+describe('toKatakana', () => {
+  it('ひらがなをカタカナに変換する', () => {
+    expect(toKatakana('とまと')).toBe('トマト')
+    expect(toKatakana('たまねぎ')).toBe('タマネギ')
+  })
+
+  it('カタカナ・漢字・英数字はそのまま', () => {
+    expect(toKatakana('トマト')).toBe('トマト')
+    expect(toKatakana('豚肉')).toBe('豚肉')
+    expect(toKatakana('abc123')).toBe('abc123')
+  })
+})
+
+describe('filterIngredientsByQuery', () => {
+  const ingredients = [
+    { id: '1', name: 'トマト' },
+    { id: '2', name: 'ミニトマト' },
+    { id: '3', name: 'たまねぎ' },
+    { id: '4', name: '鶏もも肉' },
+  ]
+
+  it('空クエリは空配列を返す', () => {
+    expect(filterIngredientsByQuery(ingredients, '')).toEqual([])
+    expect(filterIngredientsByQuery(ingredients, '   ')).toEqual([])
+  })
+
+  it('部分一致でヒットする', () => {
+    const result = filterIngredientsByQuery(ingredients, 'トマト')
+    expect(result.map((i) => i.id)).toEqual(['1', '2'])
+  })
+
+  it('ひらがな入力でカタカナ食材にヒットする', () => {
+    const result = filterIngredientsByQuery(ingredients, 'とまと')
+    expect(result.map((i) => i.id)).toEqual(['1', '2'])
+  })
+
+  it('カタカナ入力でひらがな食材にヒットする', () => {
+    const result = filterIngredientsByQuery(ingredients, 'タマネギ')
+    expect(result.map((i) => i.id)).toEqual(['3'])
+  })
+
+  it('excludeIds に含まれる食材は除外する', () => {
+    const result = filterIngredientsByQuery(ingredients, 'トマト', new Set(['1']))
+    expect(result.map((i) => i.id)).toEqual(['2'])
+  })
+
+  it('一致なしは空配列', () => {
+    expect(filterIngredientsByQuery(ingredients, 'さんま')).toEqual([])
+  })
+})

--- a/src/lib/recipe/search-ingredient.ts
+++ b/src/lib/recipe/search-ingredient.ts
@@ -1,0 +1,34 @@
+/**
+ * 食材の検索フィルタ
+ * 手動紐付け・レシピ絞り込みの両方で使う、食材名の部分一致検索ロジック
+ */
+
+/** ひらがな → カタカナ に正規化（大文字小文字も統一） */
+export function toKatakana(str: string): string {
+  return str.replace(/[ぁ-ゖ]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) + 0x60))
+}
+
+interface SearchableIngredient {
+  id: string
+  name: string
+}
+
+/**
+ * 検索クエリで食材を部分一致フィルタする
+ * ひらがな/カタカナ・大文字小文字の違いを吸収する
+ *
+ * @param ingredients 検索対象の食材配列
+ * @param query 検索文字列（空・空白のみの場合は空配列を返す）
+ * @param excludeIds 結果から除外する食材ID（選択済みなど）
+ */
+export function filterIngredientsByQuery<T extends SearchableIngredient>(
+  ingredients: T[],
+  query: string,
+  excludeIds: Set<string> = new Set()
+): T[] {
+  if (!query.trim()) return []
+  const normalized = toKatakana(query.toLowerCase())
+  return ingredients.filter(
+    (ing) => toKatakana(ing.name.toLowerCase()).includes(normalized) && !excludeIds.has(ing.id)
+  )
+}


### PR DESCRIPTION
## Summary

- メイン食材の手動紐付けが「カテゴリから選択」しかできなかったため、食材名で検索して選択できるようにした
- `ingredient-picker.tsx`（新規）: 検索欄を追加し、入力があれば部分一致の検索結果、空ならカテゴリ一覧を表示。最大5件制限を尊重
- 検索は新規追加時に入力欄をクリアし、連続で次の食材を探しやすくした（レシピ検索フィルター側の挙動に合わせた）
- `search-ingredient.ts`（新規）: 食材名の部分一致検索ロジックを共通化（ひらがな/カタカナ・大文字小文字を吸収）。ユニットテストを追加
- `use-ingredient-filter.ts`: 重複していた検索ロジックを共通関数に置き換え
- Sheet のスクロール領域に `pt-2` を追加し、検索インプットのフォーカスリング上端の見切れを修正

## Test plan

- [ ] レシピ追加/編集フォームでメイン食材の「追加」→ 検索欄に食材名（ひらがな入力含む）を入力 → 部分一致で候補が出る → タップで選択できる
- [ ] 候補を選択すると入力欄がクリアされる／検索欄を空にするとカテゴリ表示に戻る
- [ ] 5件選択済みで検索結果・カテゴリ両方の未選択候補が disabled になる
- [ ] レシピ詳細の再取得ダイアログでも同様に動作する
- [x] `npm run lint` / `npm run build` パス
- [x] ユニットテスト（`search-ingredient.test.ts`）パス

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)