### PR TITLE
fix: 自動追加された食材を即時有効化し、重複失敗をバッチ結果に計上 (#148)

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -12,6 +12,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Edge Function の共有ロジックは gitignore 対象の生成物のため、
+      # クリーンチェックアウトには存在しない。config.toml が宣言している関数を
+      # supabase start がバンドルしようとして落ちるので、先に生成しておく。
+      - name: Build Edge Functions
+        run: npm run functions:build
+
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:

--- a/SESSION.md
+++ b/SESSION.md
@@ -12,6 +12,7 @@
 未完了タスクの正本は GitHub Issues（`gh issue list --state open`）。ここには方針レベルの塊だけ:
 
 - **公開・宣伝** — #132 Gemini 有料 tier 判断
+- **食材マッチングの積み残し**（#144 の検討中に判明。着手順は #148 → #147 → #149 が素直）— #148 自動追加食材が `needs_review=true` で行き止まり（LLM 呼び出しを無駄に繰り返す・コスト影響あり）、#147 エイリアス生成後にレシピが再リンクされない、#149 ARCHITECTURE.md の auto-alias 記述が実装とズレ
 - **保守・リファクタ** — #106 API コールの typed 関数集約、#48 画像ホットリンク→next/image プロキシ、#37〜#39 E2E テスト、#110 RLS 実効化（defense-in-depth・優先度低）
 - **パッケージアップデート継続**（`/update-packages`）— G3 AI SDK / G4 UI(`lucide-react` major) / G6 開発ツール(`typescript`6, `eslint`10 等 major 多数) / G7 その他(`zod`, `schema-dts`2)
 
@@ -28,6 +29,8 @@
 - **ローカルでレシピ追加には `dev-user-001` の users 行が必要**（`supabase/seed.sql`）。無いと create 失敗 → `npx supabase db reset` で seed 再投入
 - **API は ID トークン検証必須**（dev は `NEXT_PUBLIC_LIFF_ID` 空でバイパス）。クライアントからの呼び出しは `useAuthedFetch` を使う
 - **Supabase キー**: アプリ全体は `SUPABASE_SECRET_KEY`（`sb_secret_...`）、Edge Functions 内部は `SUPABASE_SERVICE_ROLE_KEY`（自動インジェクト）
+- **pg_cron の command に secret key が平文で埋まっている**（`SELECT * FROM cron.job;` で見える）。キーをローテーションしたら cron ジョブも貼り直しが必要
+- **`scripts/setup-cron.ts` は cron ジョブを網羅していない**。同スクリプトが作るのは `generate-embeddings` と `cleanup-cron-logs` の2つで、本番の `auto-alias-daily`（毎日 18:00 UTC）はダッシュボードで手動登録されたもの。スクリプトを流し直しても復活しない
 - **fnm の PATH**: ターミナル起動時に `eval "$(fnm env --use-on-cd --shell zsh)"` が必要
 - **本番/staging で `NEXT_PUBLIC_APP_URL` 設定必須**（未設定だと LINE トーク上の規約・プライバシーリンクが機能しない）
 
@@ -36,6 +39,7 @@
 - `docs/DATABASE_DESIGN.md` - DB設計
 - `docs/SCRAPING_POLICY.md` - スクレイピング方針・規約確認記録の正本
 - `src/lib/recipe/parse-recipe.ts` - 解析フロー（JSON-LD → __NEXT_DATA__ → OGP → 空結果）
+- `src/lib/search/` - 検索ロジックの正本。LINE Bot と Web（`get-recipes` Edge Function）で共有し、Edge へは `npm run functions:build` でコピーされる（共有元を増やしたら `supabase-functions.yml` の `paths` にも追加）
 - `src/lib/auth/verify-line-token.ts` / `src/lib/api/auth-guard.ts` - ID トークン検証・API 認証ガード
 - `supabase/migrations/20260702000000_clarify_rls_policies.sql` - RLS（service_role ベース・設計意図をコメント記載）
 - `.claude/skills/legal-check/skill.md` - 法的リスクチェック（Issue 一元化・線引き基準）

--- a/docs/ADR-001-ingredient-matching.md
+++ b/docs/ADR-001-ingredient-matching.md
@@ -75,7 +75,7 @@
 2. 上位100件を処理対象
 3. LLM（Gemini）に一括で問い合わせ（1回のAPI呼び出し）
    - マッチ → ingredient_aliases に登録（auto_generated = true）
-   - 新規 → ingredients に追加（needs_review = true）
+   - 新規 → ingredients に追加（auto_generated = true / 即時有効）
 4. 処理済みを unmatched_ingredients から削除
 ```
 
@@ -85,7 +85,7 @@
 |------|-----|
 | バッチ頻度 | 1日1回 |
 | 処理上限 | 100件/日 |
-| マッチしない場合 | 新規食材として追加（要レビュー） |
+| マッチしない場合 | 新規食材として追加（即時有効 + 事後監査） |
 
 ## 理由
 
@@ -105,6 +105,10 @@
 ALTER TABLE ingredient_aliases
 ADD COLUMN auto_generated BOOLEAN DEFAULT FALSE,
 ADD COLUMN created_at TIMESTAMPTZ DEFAULT NOW();
+
+-- ingredients に追加（Issue #148）
+ALTER TABLE ingredients
+ADD COLUMN auto_generated BOOLEAN DEFAULT FALSE;
 
 -- 未マッチ食材の出現頻度取得用RPC
 CREATE FUNCTION get_unmatched_ingredient_counts(limit_count INTEGER)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -274,7 +274,7 @@ graph TB
 
 | 関数 | トリガー | 処理方式 | 説明 |
 |------|---------|---------|------|
-| `get-recipes` | API Route | 同期 | レシピ一覧取得（複数クエリ） |
+| `get-recipes` | API Route | 同期 | レシピ一覧取得・検索（複数クエリ） |
 | `generate-embeddings` | pg_cron (5分毎) | 同期 | 埋め込みベクトル生成 |
 | `auto-alias` | pg_cron (1日1回) | **非同期** | 食材エイリアス自動生成 |
 
@@ -309,12 +309,21 @@ sequenceDiagram
 
 ### ソースコード管理
 
-Edge Function の共有ロジックは `src/lib/batch/` で管理し、ビルド時に Deno 用に変換。
+Edge Function の共有ロジックは `src/lib/` 配下で管理し、ビルド時に Deno 用に変換。
 
 ```
-src/lib/batch/     →  npm run functions:build  →  supabase/functions/*/
-(Node.js)                                          (Deno)
+src/lib/batch/     →  npm run functions:build  →  supabase/functions/auto-alias/
+src/lib/search/                                   supabase/functions/get-recipes/search/
+(Node.js)                                         (Deno)
 ```
+
+| 共有元 | 利用する Edge Function | 内容 |
+|--------|------------------------|------|
+| `src/lib/batch/` | `auto-alias` | エイリアス自動生成（ローカルスクリプトと共有） |
+| `src/lib/search/` | `get-recipes` | 検索クエリの解決・絞り込み（LINE Bot と共有） |
+
+> 共有元を追加したら `.github/workflows/supabase-functions.yml` の `paths` にも追加すること。
+> 生成物は gitignore 対象のため、追加しないとソース変更時にデプロイが走らない。
 
 > 詳細は `docs/EDGE_FUNCTIONS.md` を参照
 

--- a/docs/DATABASE_DESIGN.md
+++ b/docs/DATABASE_DESIGN.md
@@ -35,7 +35,8 @@
 - `id`: UUID (Primary Key)
 - `name`: String (Unique) -- "なす"
 - `category`: String -- "野菜", "肉", "魚介" 等
-- `needs_review`: Boolean (デフォルト false、AI が自動追加した場合は true)
+- `needs_review`: Boolean (デフォルト false、人手で要確認の印を付ける用途。書き込む処理は現状なし)
+- `auto_generated`: Boolean (auto-alias バッチによる自動追加フラグ、デフォルト false)
 - `parent_id`: UUID (Foreign Key → ingredients.id) -- 親食材（例: 豚バラ肉 → 豚肉）
 - `created_at`: Timestamp
 
@@ -86,7 +87,7 @@ users ─────< recipes >───── recipe_ingredients >────
   3. 部分一致検索（マスター食材が入力に含まれるか、最長優先）
      例: "豚肉細切れ".includes("豚肉") → マッチ！
   4. マッチなし → unmatched_ingredients に記録
-     → auto-alias Edge Function（バッチ）が後からエイリアス登録 or 新規食材追加（needs_review=true）
+     → auto-alias Edge Function（バッチ）が後からエイリアス登録 or 新規食材追加（auto_generated=true）
   ↓
 recipe_ingredients に紐づけを保存
 ```
@@ -185,8 +186,8 @@ recipe_ingredients に紐づけを保存
 
 **運用方針:**
 - 初期データとして DB に投入
-- AI が新規食材を出力した場合は自動追加（`needs_review` フラグ付き）
-- 定期的にレビューして整理
+- AI が新規食材を出力した場合は即時有効な状態で自動追加（`auto_generated` フラグ付き）
+- 定期的にレビューして整理（事後監査）
 
 ## RPC 関数
 

--- a/src/lib/batch/alias-db.test.ts
+++ b/src/lib/batch/alias-db.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { insertNewIngredient } from './alias-db'
+
+/**
+ * insert().select().single() の戻り値だけを差し替えた最小のモッククライアント。
+ * insert に渡されたペイロードを検証できるよう spy を返す。
+ */
+function createMockClient(response: { data: unknown; error: unknown }) {
+  const insert = vi.fn(() => ({
+    select: () => ({ single: async () => response }),
+  }))
+  const client = { from: () => ({ insert }) } as unknown as SupabaseClient
+  return { client, insert }
+}
+
+describe('insertNewIngredient', () => {
+  it('needs_review=false / auto_generated=true で登録する', async () => {
+    const { client, insert } = createMockClient({ data: { id: 'ing-1' }, error: null })
+
+    const result = await insertNewIngredient(client, '厚揚げ', '豆腐・大豆製品')
+
+    expect(result).toEqual({ id: 'ing-1', error: null })
+    expect(insert).toHaveBeenCalledWith({
+      name: '厚揚げ',
+      category: '豆腐・大豆製品',
+      needs_review: false,
+      auto_generated: true,
+    })
+  })
+
+  it('未知のカテゴリはデフォルト（その他）に落とす', async () => {
+    const { client, insert } = createMockClient({ data: { id: 'ing-2' }, error: null })
+
+    await insertNewIngredient(client, '謎の食材', '存在しないカテゴリ')
+
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'その他' })
+    )
+  })
+
+  it('重複（23505）をエラーとして返す', async () => {
+    // マスタに既にある食材が未マッチとして再来したケース。
+    // 黙って握り潰すとバッチ結果に出ず、マッチャーの取りこぼしに気付けない（Issue #148）
+    const { client } = createMockClient({
+      data: null,
+      error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+    })
+
+    const result = await insertNewIngredient(client, '唐辛子', '野菜')
+
+    expect(result.id).toBeNull()
+    expect(result.error).toContain('唐辛子')
+  })
+
+  it('その他の DB エラーもエラーとして返す', async () => {
+    const { client } = createMockClient({
+      data: null,
+      error: { code: '42501', message: 'permission denied' },
+    })
+
+    const result = await insertNewIngredient(client, 'サラダチキン', '肉')
+
+    expect(result.id).toBeNull()
+    expect(result.error).toContain('サラダチキン')
+  })
+})

--- a/src/lib/batch/alias-db.ts
+++ b/src/lib/batch/alias-db.ts
@@ -84,11 +84,30 @@ export async function insertAlias(
   return true
 }
 
+/**
+ * 新規食材の追加結果
+ *
+ * 重複（23505）を含む失敗を呼び出し元がバッチ結果に計上できるよう、
+ * ID だけでなく失敗理由も返す（Issue #148）
+ */
+export interface InsertIngredientResult {
+  id: string | null
+  error: string | null
+}
+
+/**
+ * LLM が「新規食材」と判定したものを食材マスターに追加する
+ *
+ * needs_review は付けない。付けるとマッチング・検索・LLM に渡すマスタ一覧の
+ * すべてから除外され、同じ食材が来るたびに LLM 判定 → 重複エラーを繰り返す
+ * 行き止まりになるため（Issue #148）。自動追加であることは auto_generated で識別し、
+ * 妥当性は事後監査で担保する。
+ */
 export async function insertNewIngredient(
   supabase: SupabaseClient,
   name: string,
   category: string
-): Promise<string | null> {
+): Promise<InsertIngredientResult> {
   const validCategory = VALID_CATEGORIES.includes(category)
     ? category
     : DEFAULT_CATEGORY
@@ -98,21 +117,24 @@ export async function insertNewIngredient(
     .insert({
       name,
       category: validCategory,
-      needs_review: true,
+      needs_review: false,
+      auto_generated: true,
     })
     .select('id')
     .single()
 
   if (error) {
+    // 23505 = name の UNIQUE 違反。マスタに既にある食材が未マッチとして再来した合図で、
+    // マッチャーの取りこぼしを示すためエラーとして計上する
     if (error.code === '23505') {
-      console.log(`[insertNewIngredient] Already exists: ${name}`)
-      return null
+      console.error(`[insertNewIngredient] Already exists: ${name}`)
+      return { id: null, error: `Ingredient already exists: ${name}` }
     }
     console.error('[insertNewIngredient] Error:', error)
-    return null
+    return { id: null, error: `Failed to insert ingredient: ${name} (${error.message})` }
   }
 
-  return data?.id ?? null
+  return { id: data?.id ?? null, error: null }
 }
 
 export async function deleteProcessedUnmatched(

--- a/src/lib/batch/alias-generator.ts
+++ b/src/lib/batch/alias-generator.ts
@@ -64,11 +64,15 @@ async function processNewIngredientItem(
     return { aliasCreated: false, newIngredientCreated: false, error: null }
   }
 
-  const newId = await insertNewIngredient(supabase, item.input, item.newIngredientCategory)
+  const { id, error } = await insertNewIngredient(
+    supabase,
+    item.input,
+    item.newIngredientCategory
+  )
   return {
     aliasCreated: false,
-    newIngredientCreated: newId !== null,
-    error: null,
+    newIngredientCreated: id !== null,
+    error,
   }
 }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -65,6 +65,7 @@ export type Database = {
       }
       ingredients: {
         Row: {
+          auto_generated: boolean | null
           category: string
           created_at: string | null
           id: string
@@ -73,6 +74,7 @@ export type Database = {
           parent_id: string | null
         }
         Insert: {
+          auto_generated?: boolean | null
           category: string
           created_at?: string | null
           id?: string
@@ -81,6 +83,7 @@ export type Database = {
           parent_id?: string | null
         }
         Update: {
+          auto_generated?: boolean | null
           category?: string
           created_at?: string | null
           id?: string

--- a/supabase/migrations/20260808000000_add_ingredients_auto_generated.sql
+++ b/supabase/migrations/20260808000000_add_ingredients_auto_generated.sql
@@ -1,0 +1,18 @@
+-- 食材マスターに自動追加フラグを追加
+-- Issue #148: auto-alias が追加した食材が needs_review=true で行き止まりになる問題の修正
+--
+-- 自動追加された食材は即座に有効（needs_review=false）にし、
+-- 「自動追加だった」ことは auto_generated で識別する。
+-- 事後監査（#150 の週次通知）はこのカラムを抽出条件に使う。
+
+ALTER TABLE ingredients
+ADD COLUMN auto_generated BOOLEAN DEFAULT FALSE;
+
+-- 既存の食材は手動登録・初期データ扱い（auto_generated = FALSE）
+
+COMMENT ON COLUMN ingredients.auto_generated IS 'auto-alias バッチによる自動追加かどうか（TRUE=自動、FALSE=手動/初期データ）';
+
+-- 事後監査（自動追加食材の一覧取得）用インデックス
+CREATE INDEX idx_ingredients_auto_generated
+ON ingredients(auto_generated)
+WHERE auto_generated = TRUE;


### PR DESCRIPTION
Closes #148

## 背景

auto-alias が追加した食材は `needs_review=true` で登録されるが、**この状態の食材を使う場所も `false` に戻す手段も存在しない**行き止まりになっていた。結果、同じ食材が来るたびに LLM 判定 → 23505 で失敗を繰り返し、しかもその失敗は `GenerateAliasesResult.errors` に載らないため気付けなかった。

## 本番の実態（調査結果）

| 項目 | 結果 |
|---|---|
| `needs_review = true` の食材 | 4件（2026-04-11 〜 05-24） |
| うち `recipe_count` / `alias_count` | すべて 0 |
| `unmatched_ingredients` | 0件 |

Issue の想定と異なり、**現時点でループは発火していません**（未マッチが 0 件なので日次バッチは空回り）。ただし 4 件のうち「唐辛子」は頻出食材なので、レシピ登録を続ければ確実に再燃します。構造的な欠陥なので修正します。

## 変更内容

1. **migration**: `ingredients.auto_generated BOOLEAN DEFAULT FALSE` を追加。#150 の監査条件がこのカラムに依存する
2. **`insertNewIngredient`**: `needs_review: false` / `auto_generated: true` で登録。マスタ一覧に載るので LLM が既存食材にマップできるようになり、ループが止まる
3. **23505 のエラー計上**: 戻り値を `{ id, error }` に変更し、重複を含む失敗を `errors` に載せる。ループ再発時に気付けるようにする
4. **テスト追加**: `alias-db.test.ts`（登録ペイロード・カテゴリのフォールバック・23505/その他エラーの伝播）
5. **docs 追従**: `DATABASE_DESIGN.md` / `ADR-001`

`needs_review` カラムは残します（書き込みを止めるだけ）。5箇所の `.eq('needs_review', false)` フィルタも変更なし。今後の位置付けは #150 で判断。

## 検証

- `npm run lint` ✅
- `npm run build` ✅
- `npx vitest run` ✅ 87 tests passed
- `supabase db reset` でマイグレーション適用確認 ✅
- `supabase gen types` の出力と `src/types/database.ts` が完全一致することを確認 ✅

## マージ後にやること

**本番の既存 `needs_review=true` 行の棚卸し。** これをやらないと該当4件はマスタ一覧に載らないままで、その食材が来る限りループが続きます。

\`\`\`sql
BEGIN;

-- ゴミデータ（2食材が「、」で連結）。参照 0 件なので安全に削除できる
DELETE FROM ingredients WHERE name = '細ネギ小口切り、七味';

-- 唐辛子輪切り → 唐辛子 のエイリアスに降格
INSERT INTO ingredient_aliases (alias, ingredient_id, auto_generated)
SELECT '唐辛子輪切り', id, TRUE FROM ingredients WHERE name = '唐辛子'
ON CONFLICT (alias) DO NOTHING;

DELETE FROM ingredients WHERE name = '唐辛子輪切り';

-- 正当な食材を有効化
UPDATE ingredients SET needs_review = FALSE, auto_generated = TRUE
WHERE name IN ('唐辛子', 'サラダチキン');

SELECT name FROM ingredients WHERE needs_review = TRUE;  -- 0件になるはず

COMMIT;
\`\`\`

## 派生的に判明したこと

4件中3件は `normalize-ingredient.ts` が**切り方（輪切り・小口切り）を除去せず、「、」による複数食材の連結も分割しない**ことに起因するゴミでした。これがゴミ流入の根本原因ですが、正規化の変更は既存マッチング全体に影響するため本 PR には含めず、別 Issue に切ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)