### PR TITLE
fix(ci): E2E で Edge Function を生成してから supabase start する＋監査通知のドキュメント修正（#150）

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,15 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Install dependencies
+        run: npm ci
+
+      # Edge Function の共有ロジックは gitignore 対象の生成物のため、
+      # クリーンチェックアウトには存在しない。config.toml が宣言している関数を
+      # supabase start がバンドルしようとして落ちるので、先に生成しておく。
+      - name: Build Edge Functions
+        run: npm run functions:build
+
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
@@ -32,9 +41,6 @@ jobs:
           eval $(supabase status --output env)
           echo "SUPABASE_SECRET_KEY=$SECRET_KEY" >> $GITHUB_ENV
           echo "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=$PUBLISHABLE_KEY" >> $GITHUB_ENV
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/SESSION.md
+++ b/SESSION.md
@@ -17,9 +17,10 @@
 - **パッケージアップデート継続**（`/update-packages`）— G3 AI SDK / G4 UI(`lucide-react` major) / G6 開発ツール(`typescript`6, `eslint`10 等 major 多数) / G7 その他(`zod`, `schema-dts`2)
 
 ## Issue 化しづらい手動メモ
-- **#150 の週次監査通知はデプロイ後の手動作業が残っている**（コードだけでは通知が始まらない）
-  1. Supabase Dashboard（staging / production 両方）→ Edge Functions → Secrets に `LINE_CHANNEL_ACCESS_TOKEN` と `LINE_ADMIN_USER_ID` を設定（admin の user id は LINE Developers console の Messaging API チャネル → 「あなたのユーザーID」）
-  2. `npx tsx scripts/setup-cron.ts --env=<env>` の出力 SQL を SQL Editor で実行（**関数デプロイ後**に）
+- **#150 の週次監査通知はデプロイ後の手動作業が残っている**（コードだけでは通知が始まらない）。staging（develop マージ後）と本番（main マージ後）で**それぞれ**実施する
+  1. Supabase Dashboard → Edge Functions → Secrets に **`LINE_ADMIN_USER_ID` を追加**（`LINE_CHANNEL_ACCESS_TOKEN` は削除済み onboarding 機能の名残で既に設定済み）。user id は対象環境の `SELECT line_user_id, display_name FROM users;` から取る（LINE の user ID はチャネルスコープのため staging と本番で異なり得る）
+  2. **その環境に関数がデプロイされた後**に `npx tsx scripts/setup-cron.ts --env=<env>` の出力 SQL を SQL Editor で実行
+  3. 出力 SQL の `net.http_post(...)` だけ単発実行して実通知を確認（古いトークンが残っていれば `LINE push failed: 401` で分かる）
 - **CLAUDE.md L17 の Scraper 記述を修正**（「Jina Reader API」→ 実装は `__NEXT_DATA__` 抽出。ARCHITECTURE.md 側は整合済み）
 - **Vercel Dashboard で Node.js を 24.x に設定**（Settings → Build & Development Settings → Node.js Version）
 

--- a/SESSION.md
+++ b/SESSION.md
@@ -28,6 +28,7 @@
 - **PR は必ず `--base develop`**（`/create-pr` を使うと安全）。過去に main へ誤マージあり（PR #95）
 - **`Closes #NNN` は develop への PR では発火しない**（GitHub はデフォルトブランチへのマージ時のみ自動クローズ）。全 PR が develop 向けのため、**Issue は main マージ後に手動で閉じる**必要がある
 - **`supabase/setup-cli` が `version: latest`** のため、コードを変えなくても CLI 更新で CI が壊れ得る。特に `test-migrations.yml` は `supabase/migrations/**` 変更時のみ動くので、壊れてから気付くまで数ヶ月空くことがある（実例: 2026-08 に `supabase start` が Edge Function の生成物を読めず失敗。`npm run functions:build` を前段に追加して解消）
+- **`supabase start` を使うワークフローには必ず `npm run functions:build` を前段に入れる**。生成物は gitignore 対象なので、クリーンチェックアウトでは `config.toml` が宣言する関数をバンドルできず `supabase start` が落ちる。**Edge Function を新規追加したら `test-migrations.yml` と `e2e.yml` の両方を確認すること**（#150 で `audit-auto-generated` を追加した際、e2e 側が漏れて main が一時的に赤くなった）
 - **Vercel Preview の Deployment Protection は Off**（staging の LINE Webhook を通すため）
 - **staging LINE Webhook URL**: `https://recipe-app-git-develop-mktus-projects.vercel.app/api/webhook/line`
 - **ローカルでのレシピ取得**: `supabase functions serve` を別ターミナルで起動が必要

--- a/docs/EDGE_FUNCTIONS.md
+++ b/docs/EDGE_FUNCTIONS.md
@@ -152,11 +152,26 @@ Edge Function で使用する環境変数は Supabase Dashboard で設定:
 - `GOOGLE_GENERATIVE_AI_API_KEY` - Gemini API キー
 
 **audit-auto-generated で必要な環境変数:**
-- `LINE_CHANNEL_ACCESS_TOKEN` - LINE push 通知用（Messaging API チャネル）
-- `LINE_ADMIN_USER_ID` - 通知先。LINE Developers console → Messaging API チャネル → 「あなたのユーザーID」
+- `LINE_CHANNEL_ACCESS_TOKEN` - LINE push 通知用（Messaging API チャネル）。**既に設定済み**
+- `LINE_ADMIN_USER_ID` - 通知先。新規に設定が必要
 
 > どちらか欠けていると 500 を返して何もしない（誤った宛先に送るより気付ける方を選ぶ）。
 > staging / production の両方に設定が必要。
+
+`LINE_ADMIN_USER_ID` の調べ方は、対象環境の SQL Editor で自分の行を引くのが確実:
+
+```sql
+SELECT line_user_id, display_name, created_at FROM users ORDER BY created_at;
+```
+
+LINE の user ID は**チャネル（プロバイダー）スコープ**で、staging と本番で Messaging API
+チャネルが分かれている（`docs/LINE_SETUP.md`）ため、**環境ごとに別の ID になり得る**。
+Webhook 経由で保存されたこの ID なら、送信元チャネルとの対応と友だち追加済みの両方が担保される。
+LINE Developers console の「あなたのユーザーID」でも取れるが、上記2条件を自分で満たす必要がある。
+
+> `LINE_CHANNEL_ACCESS_TOKEN` は削除済みの onboarding 機能の名残で既に入っている。
+> その後 LINE console でトークンを再発行していると古い値のままなので、
+> 有効性は初回の単発実行（下記 pg_cron の項）で確認する（無効なら `LINE push failed: 401`）。
 
 ## pg_cron との連携
 


### PR DESCRIPTION
## Summary

main で `E2E Tests` が失敗している問題の修正と、PR #155 のマージ時に取り残されたドキュメント修正。

### CI 修正（main が赤い原因）

```
failed to read file: open supabase/functions/audit-auto-generated/auto-generated-report.ts: no such file or directory
```

#150 で追加した Edge Function の共有ロジックは gitignore 対象の生成物なので、クリーンチェックアウトの `e2e.yml` では `config.toml` が宣言する関数を `supabase start` がバンドルできず落ちていた。`test-migrations.yml` が 85c3a24 で受けたのと同じ対処を入れる。

- `npm ci` を `supabase start` より前に移し、間に `npm run functions:build` を挟む
- Edge Function を新規追加したら `test-migrations.yml` と `e2e.yml` の両方を確認する旨を SESSION.md の gotcha に追記

### ドキュメント修正

- `LINE_CHANNEL_ACCESS_TOKEN` は Supabase の Edge Function Secrets に**既に登録済み**（削除済み onboarding 機能の名残）。新規に必要なのは `LINE_ADMIN_USER_ID` だけ
- `LINE_ADMIN_USER_ID` は対象環境の `SELECT line_user_id, display_name FROM users;` から取る手順を第一候補にする。LINE の user ID はチャネルスコープで、staging と本番で Messaging API チャネルが分かれているため環境ごとに異なり得る
- cron 登録は環境ごと（develop マージ後に staging / main マージ後に本番）に分かれる点を明記

## Test plan

- [ ] この PR の `E2E Tests` が通ること（`supabase start` が落ちないこと）
- [x] コード・挙動の変更なし（ワークフローとドキュメントのみ）

Issue #150 の続き。**main が赤い状態なので、develop マージ後は main まで通すこと。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)