### PR TITLE
fix(ci): E2E Tests でテスト0本を許容する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,8 +45,10 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      # e2e/ にテストが1本も無い間は "No tests found" で落ちる。常時赤いと本物の
+      # 失敗が埋もれるため、0本を許容する。実テストが入れば通常どおり検証される（#37〜#39）
       - name: Run E2E tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --pass-with-no-tests
 
       - name: Upload test report
         uses: actions/upload-artifact@v4

--- a/SESSION.md
+++ b/SESSION.md
@@ -29,6 +29,7 @@
 - **`Closes #NNN` は develop への PR では発火しない**（GitHub はデフォルトブランチへのマージ時のみ自動クローズ）。全 PR が develop 向けのため、**Issue は main マージ後に手動で閉じる**必要がある
 - **`supabase/setup-cli` が `version: latest`** のため、コードを変えなくても CLI 更新で CI が壊れ得る。特に `test-migrations.yml` は `supabase/migrations/**` 変更時のみ動くので、壊れてから気付くまで数ヶ月空くことがある（実例: 2026-08 に `supabase start` が Edge Function の生成物を読めず失敗。`npm run functions:build` を前段に追加して解消）
 - **`supabase start` を使うワークフローには必ず `npm run functions:build` を前段に入れる**。生成物は gitignore 対象なので、クリーンチェックアウトでは `config.toml` が宣言する関数をバンドルできず `supabase start` が落ちる。**Edge Function を新規追加したら `test-migrations.yml` と `e2e.yml` の両方を確認すること**（#150 で `audit-auto-generated` を追加した際、e2e 側が漏れて main が一時的に赤くなった）
+- **`E2E Tests` は現状ほぼ何も検証していない**。`e2e/` にテストが1本も無く、`--pass-with-no-tests` で緑にしているだけ（トリガーは main への push と `workflow_dispatch` のみ、PR では走らない）。実テストは #37〜#39 で書く。現時点で守れているのは「`supabase start` が通る」ことだけ
 - **Vercel Preview の Deployment Protection は Off**（staging の LINE Webhook を通すため）
 - **staging LINE Webhook URL**: `https://recipe-app-git-develop-mktus-projects.vercel.app/api/webhook/line`
 - **ローカルでのレシピ取得**: `supabase functions serve` を別ターミナルで起動が必要


### PR DESCRIPTION
## Summary

main の `E2E Tests` が常時 failure になっている状態を解消する。

`e2e/` には `fixtures/` しか無くテストファイルが1本も無いため、Playwright が `Error: No tests found` で終了コード1を返していた。履歴を見ると **2026-07 以前から main への push すべてで failure** している。

```
2026-08-12  failure  ← No tests found
2026-08-11  failure  ← supabase start（#150 の regression、PR #157 で修正済み）
2026-08-09  failure  ← No tests found
2026-08-02  failure  ← No tests found
（以降も同様）
```

常時赤いと本物の失敗が埋もれる。実際 8/11 は「私が入れた regression」と「元々の 0 本」が重なった状態で、切り分けにログを読む必要があった。

- `npm run test:e2e -- --pass-with-no-tests` で0本を許容する（`@playwright/test` 1.58 でサポート済み）
- 実テストが入れば通常どおり検証される（#37〜#39）
- 「現状 E2E が守っているのは `supabase start` が通ることだけ」という実態を SESSION.md の gotcha に明記

## Test plan

- [x] ローカルで `npx playwright test --pass-with-no-tests` が exit 0 を返すことを確認
- [ ] マージ後、main への push で `E2E Tests` が緑になること（PR では走らないトリガー設定のため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)