### PR TITLE
fix: 正規化で切り方を除去し「、」連結の食材を分割する（Issue #152）

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -511,7 +511,8 @@ graph TB
 
 ```mermaid
 graph TB
-    Input["AI extracted ingredient"] --> Normalize["Normalize（分量・単位を除去）"]
+    Input["AI extracted ingredient"] --> Split["「、」で分割（並記された複数食材を個別に扱う）"]
+    Split --> Normalize["Normalize（分量・単位・切り方・ブランド名を除去）"]
     Normalize --> SeasoningCheck{"調味料チェック"}
 
     SeasoningCheck -->|調味料| Skip["スキップ（登録しない）"]

--- a/src/lib/recipe/match-ingredients.ts
+++ b/src/lib/recipe/match-ingredients.ts
@@ -1,7 +1,8 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 import { createServerClient } from '@/lib/db/client'
 import type { Database } from '@/types/database'
-import { normalizeIngredientName } from './normalize-ingredient'
+import { normalizeSearchKey } from '@/lib/search/normalize'
+import { normalizeIngredientName, splitIngredientNames } from './normalize-ingredient'
 
 /** 検索対象外とする調味料・基礎食材・お菓子材料 */
 const SEASONING_KEYWORDS = [
@@ -22,9 +23,12 @@ const SEASONING_KEYWORDS = [
   'お湯', '水',
 ]
 
+/** 照合キー化した調味料キーワード（かな/カナ・全角半角の揺れを吸収するため事前変換） */
+const SEASONING_KEYS = SEASONING_KEYWORDS.map(normalizeSearchKey)
+
 function isSeasoning(name: string): boolean {
-  const normalized = name.toLowerCase()
-  return SEASONING_KEYWORDS.some((kw) => normalized.includes(kw))
+  const normalized = normalizeSearchKey(name)
+  return SEASONING_KEYS.some((kw) => normalized.includes(kw))
 }
 
 export interface MatchResult {
@@ -44,8 +48,36 @@ interface Ingredient {
 type TypedSupabaseClient = SupabaseClient<Database>
 
 /**
- * 1食材を処理してマッチ結果を results に追加する。
+ * 分割済みの1断片を処理してマッチ結果を results に追加する。
  * アンマッチの場合は未マッチ記録用の normalizedName を返す。
+ */
+function processNamePart(
+  part: string,
+  allIngredients: Ingredient[],
+  ingredientIdMap: Map<string, Ingredient>,
+  aliasMap: Map<string, string>,
+  seen: Set<string>,
+  results: MatchResult[],
+): string | null {
+  const normalizedName = normalizeIngredientName(part)
+  const matched = matchSingleIngredient(allIngredients, ingredientIdMap, aliasMap, part)
+  if (matched) {
+    if (!seen.has(matched.id)) {
+      seen.add(matched.id)
+      results.push({ ingredientId: matched.id, name: matched.name })
+    }
+    return null
+  }
+  if (normalizedName && !isSeasoning(normalizedName)) {
+    return normalizedName
+  }
+  return null
+}
+
+/**
+ * 1エントリを処理してマッチ結果を results に追加する。
+ * 「細ネギ小口切り、七味」のように複数食材が並記されている場合は分割して個別に扱う。
+ * アンマッチの場合は未マッチ記録用の normalizedName を返す（分割時は複数件）。
  */
 function processSingleName(
   name: string,
@@ -54,19 +86,15 @@ function processSingleName(
   aliasMap: Map<string, string>,
   seen: Set<string>,
   results: MatchResult[],
-): string | null {
-  if (!name.trim()) return null
-  const normalizedName = normalizeIngredientName(name)
-  const matched = matchSingleIngredient(allIngredients, ingredientIdMap, aliasMap, name)
-  if (matched && !seen.has(matched.id)) {
-    seen.add(matched.id)
-    results.push({ ingredientId: matched.id, name: matched.name })
-    return null
+): string[] {
+  const unmatched: string[] = []
+  for (const part of splitIngredientNames(name)) {
+    const normalizedName = processNamePart(
+      part, allIngredients, ingredientIdMap, aliasMap, seen, results
+    )
+    if (normalizedName) unmatched.push(normalizedName)
   }
-  if (!matched && normalizedName && !isSeasoning(normalizedName)) {
-    return normalizedName
-  }
-  return null
+  return unmatched
 }
 
 /** ingredients と ingredient_aliases を一括フェッチしてインメモリ検索用データを構築 */
@@ -188,9 +216,9 @@ export async function matchIngredients(
 
   for (const name of ingredientNames) {
     const unmatched = processSingleName(name, allIngredients, ingredientIdMap, aliasMap, seen, results)
-    if (unmatched) {
+    for (const normalizedName of unmatched) {
       unmatchedPromises.push(
-        recordUnmatchedIngredient(supabase, name, unmatched, options.recipeId)
+        recordUnmatchedIngredient(supabase, name, normalizedName, options.recipeId)
       )
     }
   }
@@ -223,9 +251,9 @@ export async function matchIngredientsForRecipes(
 
     for (const name of ingredientNames) {
       const unmatched = processSingleName(name, allIngredients, ingredientIdMap, aliasMap, seen, results)
-      if (unmatched) {
+      for (const normalizedName of unmatched) {
         unmatchedPromises.push(
-          recordUnmatchedIngredient(supabase, name, unmatched, recipeId)
+          recordUnmatchedIngredient(supabase, name, normalizedName, recipeId)
         )
       }
     }

--- a/src/lib/recipe/normalize-ingredient.test.ts
+++ b/src/lib/recipe/normalize-ingredient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeIngredientName } from './normalize-ingredient'
+import { normalizeIngredientName, splitIngredientNames } from './normalize-ingredient'
 
 describe('normalizeIngredientName', () => {
   describe('基本的な正規化', () => {
@@ -81,6 +81,47 @@ describe('normalizeIngredientName', () => {
     })
   })
 
+  describe('切り方の除去', () => {
+    it('切り方を除去して基底食材名に寄せる', () => {
+      expect(normalizeIngredientName('唐辛子輪切り')).toBe('唐辛子')
+      expect(normalizeIngredientName('きゅうり小口切り')).toBe('きゅうり')
+      expect(normalizeIngredientName('にんにくみじん切り')).toBe('にんにく')
+      expect(normalizeIngredientName('大根いちょう切り')).toBe('大根')
+      expect(normalizeIngredientName('鶏もも肉そぎ切り')).toBe('鶏もも肉')
+    })
+
+    it('括弧付きの切り方も除去する', () => {
+      expect(normalizeIngredientName('唐辛子（輪切り）')).toBe('唐辛子')
+      expect(normalizeIngredientName('ねぎ(小口切り)')).toBe('ねぎ')
+    })
+
+    it('長い切り方を優先して除去する（残骸を残さない）', () => {
+      // 「みじん切り」が先にマッチすると「粗」が残ってしまう
+      expect(normalizeIngredientName('玉ねぎ粗みじん切り')).toBe('玉ねぎ')
+      expect(normalizeIngredientName('玉ねぎくし形切り')).toBe('玉ねぎ')
+    })
+  })
+
+  describe('切り方に見えるが除去してはいけない語', () => {
+    it('食材名の一部である「こま切れ」を保持する', () => {
+      // マスタに `豚こま切れ肉` `牛こま切れ肉` が存在する
+      expect(normalizeIngredientName('豚こま切れ肉')).toBe('豚こま切れ肉')
+      expect(normalizeIngredientName('牛こま切れ肉')).toBe('牛こま切れ肉')
+      expect(normalizeIngredientName('豚細切れ肉')).toBe('豚細切れ肉')
+    })
+
+    it('「薄切り」は除去しない', () => {
+      // マスタに `牛薄切り肉` が存在するため、除去すると `牛肉` に丸まって粒度が落ちる
+      expect(normalizeIngredientName('牛薄切り肉')).toBe('牛薄切り肉')
+      expect(normalizeIngredientName('豚バラ薄切り肉')).toBe('豚バラ薄切り肉')
+    })
+
+    it('「切り」を含むだけの食材名を保持する', () => {
+      expect(normalizeIngredientName('切り干し大根')).toBe('切り干し大根')
+      expect(normalizeIngredientName('豚肉切り落とし')).toBe('豚肉切り落とし')
+    })
+  })
+
   describe('エッジケース', () => {
     it('空文字列を処理できる', () => {
       expect(normalizeIngredientName('')).toBe('')
@@ -95,5 +136,49 @@ describe('normalizeIngredientName', () => {
       expect(normalizeIngredientName('鶏肉')).toBe('鶏肉')
       expect(normalizeIngredientName('トマト')).toBe('トマト')
     })
+  })
+})
+
+describe('splitIngredientNames', () => {
+  it('「、」で並記された食材を分割する', () => {
+    expect(splitIngredientNames('細ネギ小口切り、七味')).toEqual(['細ネギ小口切り', '七味'])
+    expect(splitIngredientNames('にんじん、玉ねぎ、じゃがいも')).toEqual([
+      'にんじん',
+      '玉ねぎ',
+      'じゃがいも',
+    ])
+  })
+
+  it('全角カンマでも分割する', () => {
+    expect(splitIngredientNames('塩，こしょう')).toEqual(['塩', 'こしょう'])
+  })
+
+  it('区切り文字が無い場合は1件で返す', () => {
+    expect(splitIngredientNames('なす')).toEqual(['なす'])
+    expect(splitIngredientNames('豚こま切れ肉 200g')).toEqual(['豚こま切れ肉 200g'])
+  })
+
+  it('「・」では分割しない', () => {
+    // 「牛・豚合いびき肉」のように単一食材で使われるため対象外
+    expect(splitIngredientNames('牛・豚合いびき肉')).toEqual(['牛・豚合いびき肉'])
+  })
+
+  it('空断片・前後の空白を落とす', () => {
+    expect(splitIngredientNames('なす、')).toEqual(['なす'])
+    expect(splitIngredientNames('なす、 、トマト')).toEqual(['なす', 'トマト'])
+    expect(splitIngredientNames('なす 、 トマト')).toEqual(['なす', 'トマト'])
+    expect(splitIngredientNames('')).toEqual([])
+    expect(splitIngredientNames('   ')).toEqual([])
+  })
+
+  it('既知の制限: 括弧の中の「、」でも分割される', () => {
+    // 「野菜にんじん」は未マッチとして auto-alias に回るが、「玉ねぎ」が拾えるぶん
+    // 分割しない場合（全体が1つのゴミ名になる）より改善するため許容する
+    expect(splitIngredientNames('野菜（にんじん、玉ねぎ）')).toEqual([
+      '野菜（にんじん',
+      '玉ねぎ）',
+    ])
+    expect(normalizeIngredientName('野菜（にんじん')).toBe('野菜にんじん')
+    expect(normalizeIngredientName('玉ねぎ）')).toBe('玉ねぎ')
   })
 })

--- a/src/lib/recipe/normalize-ingredient.ts
+++ b/src/lib/recipe/normalize-ingredient.ts
@@ -36,7 +36,60 @@ const BRAND_NAMES = [
 ]
 
 /**
- * 食材名から分量・単位・調理用語・ブランド名を除去して正規化する
+ * 除去対象の切り方リスト
+ *
+ * 食材名に混ざる切り方を落として基底食材名に寄せる。
+ * 除去してよいのは「マスタ名・エイリアスに現れない語」だけなので、追加時は注意:
+ * - `薄切り` は除去しない（マスタに `牛薄切り肉` が実在し、除去すると `牛肉` に丸まる）
+ * - `こま切れ` `細切れ` `切り落とし` も除去しない（`豚こま切れ肉` 等、食材名の一部）
+ *
+ * 並び順が重要: 正規表現の交替は左優先でマッチするため、長い語を先に置く。
+ * （`みじん切り` が先だと `粗みじん切り` → `粗` が残る）
+ */
+const CUTTING_STYLES = [
+  '粗みじん切り',
+  'みじん切り',
+  'いちょう切り',
+  'さいの目切り',
+  '拍子木切り',
+  'くし形切り',
+  'くし切り',
+  '小口切り',
+  '短冊切り',
+  '半月切り',
+  'ざく切り',
+  'そぎ切り',
+  'ぶつ切り',
+  '斜め切り',
+  '輪切り',
+  '千切り',
+  'せん切り',
+  '乱切り',
+  '角切り',
+]
+
+/** 食材名の並記に使われる区切り文字（`・` は `牛・豚合いびき肉` があるため対象外） */
+const NAME_DELIMITER = /[、，]/
+
+/**
+ * 並記された食材名を分割する
+ *
+ * レシピサイトによっては「細ネギ小口切り、七味」のように複数食材が
+ * 1エントリに詰め込まれる。正規化前に分割し、断片ごとにマッチングへ回す。
+ *
+ * @example
+ * splitIngredientNames('細ネギ小口切り、七味') // → ['細ネギ小口切り', '七味']
+ * splitIngredientNames('なす') // → ['なす']
+ */
+export function splitIngredientNames(raw: string): string[] {
+  return raw
+    .split(NAME_DELIMITER)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+}
+
+/**
+ * 食材名から分量・単位・調理用語・切り方・ブランド名を除去して正規化する
  *
  * @example
  * normalizeIngredientName('豚肉細切れ 200g') // → '豚肉細切れ'
@@ -45,10 +98,13 @@ const BRAND_NAMES = [
  * normalizeIngredientName('鶏もも肉（皮なし） 300g') // → '鶏もも肉皮なし'
  * normalizeIngredientName('キッコーマン醤油') // → '醤油'
  * normalizeIngredientName('マンジョウ本みりん') // → '本みりん'
+ * normalizeIngredientName('唐辛子（輪切り）') // → '唐辛子'
  */
 export function normalizeIngredientName(raw: string): string {
   // ブランド名除去用の正規表現を構築
   const brandPattern = new RegExp(BRAND_NAMES.join('|'), 'g')
+  // 切り方除去用の正規表現を構築
+  const cuttingStylePattern = new RegExp(CUTTING_STYLES.join('|'), 'g')
 
   return (
     raw
@@ -65,6 +121,9 @@ export function normalizeIngredientName(raw: string): string {
       .replace(/[（()）]/g, '')
       // その他の括弧記号を除去
       .replace(/[【】\[\]「」『』]/g, '')
+      // 切り方の除去（例: 唐辛子輪切り → 唐辛子）
+      // 括弧除去の後に置くことで「唐辛子（輪切り）」も拾える
+      .replace(cuttingStylePattern, '')
       // 調理用語・分量表現の除去
       .replace(
         /少々|適量|お好みで|大さじ|小さじ|カップ|ひとつまみ|適宜|ひとかけ|少量|たっぷり|お好み|to taste/gi,


### PR DESCRIPTION
## Summary

食材名の正規化が切り方（輪切り・小口切り等）を落とさず、「、」で並記された複数食材も1つの名前として扱っていた。この正規化結果は `unmatched_ingredients.normalized_name` に記録され、auto-alias がそれをエイリアス名・新規食材名にそのまま流用するため、`細ネギ小口切り、七味` のようなゴミが食材マスタに混入していた（本番の自動追加食材4件中3件がこれに起因）。

- **切り方の除去** — `CUTTING_STYLES` を追加。括弧除去の後に適用するので `唐辛子（輪切り）` も拾える。正規表現の交替は左優先のため長い語を先に並べている（`粗みじん切り` → `粗` の残骸を防ぐ）
- **「、」での分割** — `splitIngredientNames` を追加し、`match-ingredients.ts` の `processSingleName` で断片ごとにマッチングへ回す。`seen` による ID 重複排除は既存のものをそのまま流用
- **調味料判定のカナ揺れ修正** — `isSeasoning` が `toLowerCase()` しかしておらず、`SEASONING_KEYWORDS` の `細ねぎ` にカタカナ入力の `細ネギ` がヒットしていなかった。既存の `normalizeSearchKey` を通すように変更

### 除去対象から意図的に外した語

マスタ名・エイリアスと衝突するため、以下は除去しない（回帰テストで固定済み）:

| 語 | 理由 |
|---|---|
| `薄切り` | マスタに `牛薄切り肉` が実在（`牛肉` の子）。除去すると `牛肉` に丸まって粒度が落ちる |
| `こま切れ` / `細切れ` / `切り落とし` | `豚こま切れ肉`・`牛こま切れ肉` など食材名の一部 |
| `刻み` / `おろし` / `すりおろし` | 「〜切り」ではなく、`SEASONING_KEYWORDS` の `ねぎ刻み` と干渉するため今回は見送り |

## Test plan

- [x] `npm test` — 112 tests passed（`normalize-ingredient.test.ts` に切り方除去・除去してはいけない語の回帰・`splitIngredientNames` のテストを追加、28 tests）
- [x] `npm run lint` — 警告なし
- [x] `npm run build` — 成功

マッチ率の数値比較（`check-ingredient-match-rate.sh`）はローカルの `unmatched_ingredients` が0行のため実施していない。正しさはユニットテストで担保し、本番反映後の推移は #150 の週次監査通知で観測する。

## スコープ外

- **既存ゴミデータの手当** — 本番の `細ネギ小口切り、七味`（→ `needs_review=true`）と `唐辛子輪切り`（→ `唐辛子` のエイリアス化＋削除）は正規化を直しても残るため、マージ後に手動 SQL で対応する
- **既存エイリアスの掃除** — `ingredient_aliases` は旧正規化の出力がキーなので切り方を含む行は今後引かれなくなるが、剥がした後の名前が完全一致／部分一致で拾われるため放置する

Refs #152

> develop 向け PR のため `Closes` は発火しない。Issue は main マージ後に手動で閉じる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)