### PR TITLE
docs: auto-alias の判定フローを追記し実装との乖離を解消（Issue #149）

### DIFF
--- a/docs/ADR-001-ingredient-matching.md
+++ b/docs/ADR-001-ingredient-matching.md
@@ -40,6 +40,14 @@
 - 調理法で区別したいケースがある（薄切り vs 細切れ）
 - ルールベースの対応は網羅が難しい
 
+> **後日の追記（2026-08 / Issue #152）**: 主軸は選択肢3のままだが、**切り方の除去だけは
+> 補助的に採用した**。`輪切り`・`小口切り`・`みじん切り` 等19語を正規化で落とす
+> （`src/lib/recipe/normalize-ingredient.ts` の `CUTTING_STYLES`）。
+> 却下理由の2点目は除外リストで担保している — マスタに実在する語を含む
+> `薄切り`（`牛薄切り肉`）・`こま切れ` / `細切れ` / `切り落とし`（`豚こま切れ肉` 等）は除去しない。
+> 却下理由の1点目（表記統一）と3点目（網羅性）は未解決のままで、そこは引き続き
+> 選択肢3のエイリアス自動拡充が受け持つ。
+
 ### 選択肢2: ベクトル埋め込みで食材マッチング
 
 ```
@@ -75,9 +83,12 @@
 2. 上位100件を処理対象
 3. LLM（Gemini）に一括で問い合わせ（1回のAPI呼び出し）
    - マッチ → ingredient_aliases に登録（auto_generated = true）
-   - 新規 → ingredients に追加（auto_generated = true / 即時有効）
-4. 処理済みを unmatched_ingredients から削除
+   - 新規 → ingredients に追加（auto_generated = true / needs_review = false = 即時有効）
+   - どちらでもない（調味料等）→ 何も登録しない
+4. 処理済みを unmatched_ingredients から削除（判定結果によらず削除する）
 ```
+
+> 判定ルールと反映時の注意点は `docs/ARCHITECTURE.md`「食材名寄せフロー > バッチでの名寄せ」を参照。
 
 ### 設定値
 
@@ -122,14 +133,16 @@ supabase/migrations/
   20260216000000_alias_auto_generate.sql  # マイグレーション
 
 src/lib/batch/
-  alias-generator.ts   # コアロジック（Node.js用）
+  alias-generator.ts   # コアロジック（Node.js / Deno 共用）
+  alias-db.ts          # DB 操作（unmatched 取得・alias / ingredient 登録・削除）
+  alias-llm.ts         # プロンプト組み立てと Gemini 呼び出し
 
 scripts/
   auto-alias.ts        # ローカル実行用スクリプト
 
 supabase/functions/
   auto-alias/
-    index.ts           # Edge Function（本番用）
+    index.ts           # Edge Function（本番用。src/lib/batch/ をビルド時にコピー）
 ```
 
 ### 使い方
@@ -152,6 +165,15 @@ npx tsx scripts/auto-alias.ts --limit=10
 
 ## 将来の拡張
 
-- 手動でエイリアス追加するUIの提供
-- 未マッチ頻度が高い食材のアラート通知
-- pg_cron でEdge Functionを定期実行（本番環境）
+| 項目 | 状態 |
+|------|------|
+| 手動でエイリアス追加するUIの提供 | 未着手 |
+| 未マッチ頻度が高い食材のアラート通知 | **相当する通知を実装済み**（Issue #150）。ただし通知対象は「未マッチ頻度が高い食材」ではなく **auto-alias が自動追加した食材**（`audit-auto-generated` が毎週月曜 09:00 JST に管理者へ LINE 通知）。未マッチのまま残る食材の可視化は未着手 |
+| pg_cron で Edge Function を定期実行（本番環境） | **実装済み**（定義の正本は `scripts/setup-cron.ts`。本番 / staging に4ジョブ登録） |
+
+## 更新履歴
+
+| 日付 | 内容 |
+|------|------|
+| 2026-02-16 | 初版（選択肢3を採用） |
+| 2026-08-24 | 実装との乖離を解消（Issue #149）: 切り方除去の限定採用（#152）を選択肢1に追記、「将来の拡張」の実装状況を反映。判定ルール・結果の反映フローは `docs/ARCHITECTURE.md`「食材名寄せフロー」に集約 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -305,18 +305,34 @@ sequenceDiagram
 
     Note over Func: Continue in background
 
-    loop For each unmatched (max 100)
-        Func->>DB: Get unmatched ingredient
-        Func->>LLM: Request classification
-        LLM-->>Func: Match result
-        alt Match found
-            Func->>DB: Register alias
-        else No match
-            Func->>DB: Add new ingredient
+    Func->>DB: get_unmatched_ingredient_counts(100)
+    DB-->>Func: 未マッチ食材（出現頻度順・最大100件）
+    Func->>DB: マスタ食材一覧（needs_review = false のみ）
+    DB-->>Func: ingredients
+
+    Func->>LLM: 未マッチ全件＋マスタ一覧をまとめて判定依頼（1回）
+    LLM-->>Func: results[]（食材ごとの判定）
+
+    loop 判定結果ごと
+        alt マッチあり
+            Func->>DB: ingredient_aliases に登録
+        else 新規食材
+            Func->>DB: ingredients に追加（即時有効）
+        else どちらでもない
+            Note over Func: 登録しない
         end
-        Func->>DB: Delete from unmatched
     end
+
+    Func->>DB: 判定結果に含まれた語を unmatched から一括削除
 ```
+
+> **Gemini 呼び出しは1実行あたり1回**。未マッチ食材は全件まとめて1つのプロンプトに載せ、
+> ループしているのは返ってきた判定結果を DB に反映する部分だけ
+> （`src/lib/batch/alias-generator.ts`）。処理上限 100 件はプロンプトに載せる語数の上限であり、
+> API 呼び出し回数ではない。
+
+> 判定ルールと結果の扱い（新規食材の即時有効・未マッチの削除条件）は
+> [食材名寄せフロー](#食材名寄せフロー) の「バッチでの名寄せ」を参照。
 
 ### ソースコード管理
 
@@ -531,7 +547,64 @@ graph TB
     Unmatched --> BatchQueue["Queue for batch (auto-alias)"]
 ```
 
-> バッチ処理の詳細は [Edge Functions](#edge-functions) セクションを参照
+> 部分一致が走査するのはマスタ食材名だけで、エイリアスは完全一致でしか使われない。
+> そのため `ねぎ → 長ねぎ` のようにエイリアスにしか存在しない語は部分一致の材料にならず、
+> `青ねぎ` ⊃ `ねぎ` の関係を使えないまま未マッチとして記録される（検索時の部分一致も同じ制約）。
+
+### バッチでの名寄せ（auto-alias の判定）
+
+未マッチとして溜まった食材は、1日1回の `auto-alias` バッチが LLM（Gemini）で
+「既存食材の表記揺れ」か「新規食材」かを判定する。
+実行の入れ物（非同期パターン・呼び出し回数）は [Edge Functions](#edge-functions) を参照。
+
+#### 判定ルール
+
+`src/lib/batch/alias-llm.ts` の `buildPrompt` が LLM に渡すルール。
+
+| # | ルール | 例 |
+|---|--------|-----|
+| 1 | 表記揺れ（カタカナ/ひらがな・漢字の違い）は同一食材として扱う | 「長ネギ」→「ねぎ」 |
+| 2 | 調理形態の違いは同一食材として扱う | 「豚バラ薄切り肉」→「豚バラ肉」 |
+| 3 | ただし食材の種類が異なる場合は区別する | 「豚バラ肉」と「豚こま肉」は別物 |
+| 4 | マスターに該当する食材がない場合は新規食材と判定 | 「ヤングコーン」→ 新規追加 |
+| 5 | 調味料や一般的でない食材は追加しない | `matchedId: null` かつ `isNewIngredient: false` |
+
+ルール2の「調理形態」は、正規化（`normalizeIngredientName`）で落としきれなかった分の
+受け皿でもある。正規化側で除去する切り方の一覧は `src/lib/recipe/normalize-ingredient.ts`
+（`CUTTING_STYLES`）を参照。
+
+#### 判定結果の反映
+
+```mermaid
+graph TB
+    Unmatched["unmatched_ingredients<br/>（出現頻度順・最大100件）"] --> Master["マスタ食材一覧を取得<br/>（needs_review = false のみ）"]
+    Master --> LLM["Gemini に一括判定（1回のAPI呼び出し）"]
+
+    LLM --> Judge{"判定結果"}
+    Judge -->|matchedId あり| Alias["ingredient_aliases に登録<br/>auto_generated = true"]
+    Judge -->|isNewIngredient| New["ingredients に追加<br/>needs_review = false / auto_generated = true"]
+    Judge -->|"どちらでもない（ルール5）"| Skip["登録しない"]
+
+    Alias --> Delete["判定結果に含まれた語を<br/>unmatched_ingredients から削除"]
+    New --> Delete
+    Skip --> Delete
+
+    New --> Audit["週次 audit-auto-generated で事後監査"]
+```
+
+#### 押さえておくべき挙動
+
+| 挙動 | 詳細 |
+|------|------|
+| 新規食材は即時有効 | `needs_review = false` で追加され、そのまま検索・マッチングに乗る。妥当性は週次の `audit-auto-generated` 通知で事後確認する（カテゴリ誤りは `UPDATE`、ゴミ食材は `needs_review = true` で退避）。`needs_review = true` で作ると読み取り側4箇所すべてから外れて行き止まりになる（#148） |
+| unmatched の削除は判定結果に依存しない | エイリアス登録・新規追加・ルール5の「登録しない」のいずれでも削除される。同じ食材が再び未マッチで積まれない限り再判定されない |
+| LLM が返さなかった語は残る | 削除対象は LLM の `results` に含まれた語だけなので、応答から漏れた語は次回の実行に持ち越される |
+| LLM に見えるマスタは `needs_review = false` のみ | レビュー中の食材は候補に出ないため同名を「新規食材」と判定してしまう。これが #148 の重複ループの原因 |
+| 新規追加の UNIQUE 違反（23505）はエラー計上 | `ingredients.name` の重複は「登録時のマッチャーが既存食材を取りこぼした」合図なので、握りつぶさずバッチ結果の `errors` に積む |
+| `ingredient_aliases.auto_generated` は書くだけ | 読み出し箇所はまだない（監査バッチが見ているのは `ingredients.auto_generated`） |
+| エイリアス名は正規化後の文字列 | `unmatched_ingredients.normalized_name` をそのままエイリアス名／新規食材名に使うため、正規化を強化すると古いエイリアスは引かれなくなる |
+
+> 設計判断の経緯は `docs/ADR-001-ingredient-matching.md` を参照。
 
 ### 検索時の解決
 
@@ -550,7 +623,7 @@ graph TB
     ExactCheck -->|No match| CategoryCheck{"カテゴリ一致（肉・魚介 等）"}
 
     CategoryCheck -->|Match| Group
-    CategoryCheck -->|No match| PartialCheck{"部分一致（双方向）"}
+    CategoryCheck -->|No match| PartialCheck{"部分一致（双方向・マスタ名のみ）"}
 
     PartialCheck -->|Match| Group
     PartialCheck -->|No match| Text["テキスト条件"]
@@ -568,7 +641,7 @@ graph TB
 | カテゴリ語 | テキスト照合には回さない（「肉」で「肉なし〇〇」を拾わないため） |
 | 未解決語 | テキスト照合に回る（マスタにない食材も材料テキストで拾える） |
 | フィルターバー選択 | 明示選択された食材IDは ID 一致のみ（テキスト照合しない） |
-| Bot のみ | テキスト条件のヒットが 3 件未満ならベクトル検索で補完 |
+| Bot のみ | テキスト条件を含むクエリで絞り込み結果が 3 件未満なら、ベクトル検索で補完（全語が食材に解決したクエリでは発動しない → #163） |
 
 > 絞り込みは DB クエリではなくユーザーのレシピを取得した上での JS フィルタで行う
 > （Bot / Web で同一の照合結果にするため）。レシピ件数が大きく増えた場合は RPC 化を検討する。


### PR DESCRIPTION
## Summary

`docs/ARCHITECTURE.md` / `docs/ADR-001-ingredient-matching.md` の auto-alias 周りの記述を実装に合わせた（Issue #149）。

**ARCHITECTURE.md**
- auto-alias のシーケンス図を修正: **Gemini 呼び出しは1実行あたり1回**（未マッチ全件を1プロンプトに載せる）。従来の図は未マッチ1件ごとに LLM を呼ぶように読めた
- 「食材名寄せフロー」に **「バッチでの名寄せ（auto-alias の判定）」** を新設
  - 判定ルール5項目（`alias-llm.ts` のプロンプト）
  - 判定結果の反映フロー図（エイリアス登録 / 新規追加 / 登録しない の3分岐 → unmatched 削除 → 週次監査）
  - 押さえておくべき挙動（削除は判定結果に依存しない・LLM が返さなかった語は残る・LLM に見えるマスタは `needs_review = false` のみ・UNIQUE 違反はエラー計上・`ingredient_aliases.auto_generated` は書くだけ 等）
- 新規食材は `needs_review = false` の**即時有効**＋週次 `audit-auto-generated` での事後監査であることを明記（#148 の対応後の実態。Issue 本文の「`needs_review: true` で作られる」は #148 以前の記述）
- 部分一致がマスタ名だけを走査しエイリアスを見ない制約を、登録時・検索時の両方に明記（Issue のコメント3）
- ベクトル検索フォールバックの発動条件を実装どおりに修正し #163 を参照

**ADR-001**
- 選択肢1「調理法除去」は却下のままだったが、#152 で**切り方の除去だけ限定採用**したことを追記（除外リストで却下理由2点目を担保している旨も）
- 「将来の拡張」3項目の実装状況を反映（アラート通知は #150 で実装済み・pg_cron 定期実行は実装済み・手動 UI は未着手）
- 処理フローに「どちらでもない」分岐と「判定結果によらず削除」を追記、ファイル構成を現状（`alias-db.ts` / `alias-llm.ts`）に更新
- 更新履歴を追加

## Test plan

- [ ] GitHub 上で ARCHITECTURE.md の mermaid 図（シーケンス図・判定結果の反映フロー）が描画されること
- [ ] ドキュメント内リンク（`#食材名寄せフロー` / `#edge-functions`）が飛ぶこと
- [ ] コード変更なし（lint / build への影響なし）

## 補足

Issue の依頼どおり `/doc-check-logic` を実行し、他セクションの同種の乖離も確認した。
- 食材名寄せフロー: 本 PR で解消
- レシピ解析フロー: 実装（JSON-LD → `__NEXT_DATA__` → OGP → 空結果）と一致
- 認証フロー: `ensureUser()` の遅延登録を含め実装と一致

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)