### PR TITLE
fix(line): Flex のアクション label を40文字に丸めて「最近追加」の無反応を解消

### DIFF
--- a/src/lib/line/category-handler.ts
+++ b/src/lib/line/category-handler.ts
@@ -63,6 +63,21 @@ async function replyText(client: MessagingApiClient, replyToken: string, text: s
   await client.replyMessage({ replyToken, messages: [{ type: 'text', text }] })
 }
 
+/**
+ * catch 内からのエラー通知用。失敗しても投げない
+ *
+ * 本命の reply が失敗した時点で replyToken が使えなくなっていることがあり、
+ * そのまま投げると webhook 全体が 500 になってユーザーには「既読のみ・無反応」に見える。
+ * ここで握ってログに残せば、少なくとも原因が追える形で終われる。
+ */
+async function replyErrorText(client: MessagingApiClient, replyToken: string, text: string): Promise<void> {
+  try {
+    await replyText(client, replyToken, text)
+  } catch (err) {
+    console.error('[LINE Webhook] エラー通知の返信にも失敗:', err)
+  }
+}
+
 /** よく作るレシピを返す（view_count 上位） */
 export async function handleYokuTsukuru(
   client: MessagingApiClient,
@@ -84,7 +99,7 @@ export async function handleYokuTsukuru(
     })
   } catch (err) {
     console.error('[LINE Webhook] handleYokuTsukuru error:', err)
-    await replyText(client, replyToken, 'レシピの取得中にエラーが発生しました。')
+    await replyErrorText(client, replyToken, 'レシピの取得中にエラーが発生しました。')
   }
 }
 
@@ -110,7 +125,7 @@ export async function handleShortCookingTime(
     })
   } catch (err) {
     console.error('[LINE Webhook] handleShortCookingTime error:', err)
-    await replyText(client, replyToken, 'レシピの取得中にエラーが発生しました。')
+    await replyErrorText(client, replyToken, 'レシピの取得中にエラーが発生しました。')
   }
 }
 
@@ -136,7 +151,7 @@ export async function handleFewIngredients(
     })
   } catch (err) {
     console.error('[LINE Webhook] handleFewIngredients error:', err)
-    await replyText(client, replyToken, 'レシピの取得中にエラーが発生しました。')
+    await replyErrorText(client, replyToken, 'レシピの取得中にエラーが発生しました。')
   }
 }
 
@@ -161,7 +176,7 @@ export async function handleRecentlyAdded(
     })
   } catch (err) {
     console.error('[LINE Webhook] handleRecentlyAdded error:', err)
-    await replyText(client, replyToken, 'レシピの取得中にエラーが発生しました。')
+    await replyErrorText(client, replyToken, 'レシピの取得中にエラーが発生しました。')
   }
 }
 

--- a/src/lib/line/flex-message.test.ts
+++ b/src/lib/line/flex-message.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { createVerticalListMessage, type RecipeCardData } from './flex-message'
+
+/** LINE のアクション label 上限。超えると reply 全体が 400 で落ちる */
+const ACTION_LABEL_MAX = 40
+
+const card = (title: string): RecipeCardData => ({
+  title,
+  url: 'https://example.com/api/track/recipe/abc',
+  imageUrl: 'https://example.com/image.jpg',
+  sourceName: 'テストサイト',
+  cookingTimeMinutes: 15,
+  ingredientCount: 5,
+})
+
+/** Flex のツリーから uri アクションを全部集める */
+function collectUriActions(node: unknown, acc: { label?: string; uri?: string }[] = []) {
+  if (Array.isArray(node)) {
+    node.forEach((child) => collectUriActions(child, acc))
+    return acc
+  }
+  if (!node || typeof node !== 'object') return acc
+  const obj = node as Record<string, unknown>
+  if (obj.type === 'uri') acc.push(obj as { label?: string; uri?: string })
+  Object.values(obj).forEach((value) => collectUriActions(value, acc))
+  return acc
+}
+
+describe('createVerticalListMessage', () => {
+  it('40文字を超えるタイトルでも action の label を上限内に収める', () => {
+    // 本番で 400 を踏んだ実際のタイトル（42文字）
+    const longTitle = 'きのことベーコンのバターしょうゆスパゲッティ【まいたけとエリンギで人気の和風パスタ】'
+    expect(longTitle.length).toBeGreaterThan(ACTION_LABEL_MAX)
+
+    const message = createVerticalListMessage([card(longTitle)], 'https://liff.line.me/x', 1, '🆕 最近追加したレシピ')
+
+    for (const action of collectUriActions(message)) {
+      expect((action.label ?? '').length).toBeLessThanOrEqual(ACTION_LABEL_MAX)
+    }
+  })
+
+  it('上限以内のタイトルはそのまま label に使う', () => {
+    const title = 'だしたまぶっかけ'
+    const message = createVerticalListMessage([card(title)], 'https://liff.line.me/x', 1, '🆕 最近追加したレシピ')
+
+    const labels = collectUriActions(message).map((a) => a.label)
+    expect(labels).toContain(title)
+  })
+
+  it('タイトルを切り詰めても表示テキストは省略しない', () => {
+    const longTitle = 'きのことベーコンのバターしょうゆスパゲッティ【まいたけとエリンギで人気の和風パスタ】'
+    const message = createVerticalListMessage([card(longTitle)], 'https://liff.line.me/x', 1)
+
+    expect(JSON.stringify(message)).toContain(longTitle)
+  })
+})

--- a/src/lib/line/flex-message.ts
+++ b/src/lib/line/flex-message.ts
@@ -20,6 +20,19 @@ const COLORS = {
 
 const DEFAULT_IMAGE = 'https://via.placeholder.com/300x200?text=No+Image'
 
+/**
+ * アクションの label の上限（LINE 仕様）
+ *
+ * 超えると reply 全体が 400 で落ちる（`label must not be longer than 40 characters`）。
+ * ボックスの action ラベルは画面に出ずアクセシビリティ用途なので、切り詰めて構わない。
+ */
+const ACTION_LABEL_MAX = 40
+
+/** レシピタイトルをアクションの label に使える長さへ丸める */
+function toActionLabel(title: string): string {
+  return title.length > ACTION_LABEL_MAX ? title.slice(0, ACTION_LABEL_MAX) : title
+}
+
 function createHeroImage(imageUrl: string | null | undefined): messagingApi.FlexImage {
   return { type: 'image', url: imageUrl || DEFAULT_IMAGE, size: 'full', aspectRatio: '20:13', aspectMode: 'cover' }
 }
@@ -153,7 +166,7 @@ function createListItemBox(recipe: RecipeCardData): messagingApi.FlexBox {
     paddingBottom: 'lg',
     paddingStart: 'md',
     paddingEnd: 'md',
-    action: { type: 'uri', label: recipe.title, uri: recipe.url },
+    action: { type: 'uri', label: toActionLabel(recipe.title), uri: recipe.url },
     contents: [
       { type: 'image', url: recipe.imageUrl || DEFAULT_IMAGE, size: 'sm', aspectRatio: '1:1', aspectMode: 'cover', flex: 0 },
       { type: 'box', layout: 'vertical', justifyContent: 'center', contents: textContents },

--- a/src/lib/line/search-handler.ts
+++ b/src/lib/line/search-handler.ts
@@ -47,6 +47,20 @@ async function replyText(params: ReplyParams, text: string): Promise<void> {
   await params.client.replyMessage({ replyToken: params.replyToken, messages: [{ type: 'text', text }] })
 }
 
+/**
+ * catch 内からのエラー通知用。失敗しても投げない
+ *
+ * 本命の reply が失敗した時点で replyToken が使えなくなっていることがあり、
+ * そのまま投げると webhook 全体が 500 になってユーザーには「既読のみ・無反応」に見える。
+ */
+async function replyErrorText(params: ReplyParams, text: string): Promise<void> {
+  try {
+    await replyText(params, text)
+  } catch (err) {
+    console.error('[LINE Webhook] エラー通知の返信にも失敗:', err)
+  }
+}
+
 async function replyWithRecipes(
   params: ReplyParams,
   recipes: SearchRecipeResult[],
@@ -88,7 +102,7 @@ export async function handleSearch(
     await replyWithRecipes(params, recipes, text)
   } catch (err) {
     console.error('[LINE Webhook] Search error:', err)
-    await replyText(params, '検索中にエラーが発生しました。')
+    await replyErrorText(params, '検索中にエラーが発生しました。')
   }
 }
 
@@ -112,7 +126,7 @@ export async function handleRecentlyViewed(
     })
   } catch (err) {
     console.error('[LINE Webhook] Recently viewed error:', err)
-    await replyText(params, '閲覧履歴の取得中にエラーが発生しました。')
+    await replyErrorText(params, '閲覧履歴の取得中にエラーが発生しました。')
   }
 }
 
@@ -136,7 +150,7 @@ export async function handleMostViewed(
     })
   } catch (err) {
     console.error('[LINE Webhook] Most viewed error:', err)
-    await replyText(params, 'よく見るレシピの取得中にエラーが発生しました。')
+    await replyErrorText(params, 'よく見るレシピの取得中にエラーが発生しました。')
   }
 }
 


### PR DESCRIPTION
## 症状

LINE の「探す」→「🆕 最近追加」をタップしても、**既読が付くだけで何も返ってこない**（本番）。
よく見る／材料少なめ／時短は正常に動作していた。

## 原因

縦リスト Flex のボックスに付けている uri アクションの `label` に、レシピタイトルをそのまま入れていた（`flex-message.ts`）。LINE のアクション label 上限は **40文字**で、超えるとメッセージ全体が 400 で弾かれる。

本番ログの LINE レスポンス:

```
{"message":"A message (messages[0]) in the request body is invalid",
 "details":[{"message":"`label` must not be longer than 40 characters",
             "property":"/body/contents/8/action"}]}
```

`contents[8]` は5件目の「きのことベーコンのバターしょうゆスパゲッティ【まいたけとエリンギで人気の和風パスタ】」（**42文字**）。

4つのリスト機能は同じ `createVerticalListMessage` を通るため、**他が動いていたのは偶然**。本番データでの各リスト上位5件の最長タイトルは以下の通りで、材料少なめはちょうど40文字で通っていた。

| リスト | 最長タイトル | 結果 |
|---|---|---|
| 最近追加 | 42文字 | ❌ 400 |
| 材料少なめ | 40文字 | ✅ |
| よく見る | 32文字 | ✅ |
| 時短 | 30文字 | ✅ |

つまり長いタイトルのレシピが上位に来れば、どのリストでも同じように落ちる状態だった。

## 変更内容

1. **`flex-message.ts`** — アクションの label を40文字に丸める（`toActionLabel`）。label は画面に表示されずアクセシビリティ用途なので切り詰めて問題ない。**表示テキスト側はタイトル全文を維持**
2. **`category-handler.ts` / `search-handler.ts`** — catch 内のエラー通知に失敗しても投げないようにした（`replyErrorText`）

2 について: 本命の reply が失敗した時点で replyToken が使えなくなっており、catch 内の通知も失敗 → webhook 全体が 500 → ユーザーには「既読のみ・無反応」に見えていた。**本当のエラーメッセージが隠れていたのが、切り分けに時間がかかった原因**。今後は最低限「レシピの取得中にエラーが発生しました。」が返るか、少なくともログに残る。

## テスト

`src/lib/line/flex-message.test.ts` を追加（本番で 400 を踏んだ実際の42文字タイトルを使用）:

- 40文字超のタイトルでも label が上限内に収まる
- 上限以内のタイトルはそのまま label に使う
- label を切り詰めても表示テキストは省略されない

## 確認

- `npm test` — 115 passed (11 files)
- `npm run lint` — クリーン
- `npm run build` — 成功
- 本番データで「最近追加」上位5件の Flex を再構築し、label 上限超え **0件**・全タイトルの表示テキスト保持を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)